### PR TITLE
Add Claude Cognitive Infrastructure setup playbook

### DIFF
--- a/Setup/Claude-Cognitive-Infrastructure/0_INITIALIZE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/0_INITIALIZE.md
@@ -1,0 +1,74 @@
+# Phase 0: Initialize
+
+## Objective
+
+Validate prerequisites and prepare for Claude Cognitive Infrastructure deployment.
+
+## Prerequisites Checklist
+
+### 1. Target Directory
+
+Verify the target agent directory:
+
+- [ ] Agent directory exists and is writable
+- [ ] Directory has a clear name indicating agent purpose
+- [ ] No critical files will be overwritten (or backup is acceptable)
+
+### 2. Existing Infrastructure Check
+
+Check for existing `.claude/` directory:
+
+- [ ] If `.claude/` exists, determine upgrade vs fresh install
+- [ ] If upgrading, backup existing memory files
+- [ ] Note any custom configurations to preserve
+
+### 3. Agent Context
+
+Gather information about the agent:
+
+- [ ] Agent name (from directory name)
+- [ ] Organization (from parent directory, if applicable)
+- [ ] Agent type/role (inferred from name or existing files)
+
+## Agent Type Detection
+
+Based on directory name, detect agent type for customization:
+
+| Keywords in Name | Agent Type | Persona Suggestion |
+|------------------|------------|-------------------|
+| Sales, Lead, Pipeline | Sales | Scout |
+| Engineer, Architect, Developer | Technical | Archon |
+| Research, Analysis | Research | Sage |
+| Marketing, Content | Marketing | Maven |
+| Fundraising, Investor | Finance | Catalyst |
+| Operations, Admin | Operations | Atlas |
+| People, Recruiting, HR | People | Harbor |
+| Executive, Chief | Executive | Aria |
+| Brand, Communications | Communications | Echo |
+| Strategy, Planning | Strategy | Compass |
+| Customer, Success | Customer | Bridge |
+| UX, Design | Design | Pixel |
+
+## Validation Steps
+
+1. Confirm agent directory path
+2. Check write permissions
+3. Detect agent type from name
+4. Check for existing infrastructure
+5. Determine installation mode (fresh/upgrade)
+
+## Installation Modes
+
+### Fresh Install
+- Create complete `.claude/` structure
+- Generate new CLAUDE.md identity
+- Initialize empty memory files
+
+### Upgrade Install
+- Preserve existing memory files
+- Update structure to latest version
+- Add new capabilities (hooks, skills)
+
+## Next Phase
+
+Once prerequisites are validated, proceed to **1_ANALYZE.md** to analyze the agent context.

--- a/Setup/Claude-Cognitive-Infrastructure/1_ANALYZE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/1_ANALYZE.md
@@ -1,0 +1,106 @@
+# Phase 1: Analyze Agent Context
+
+## Objective
+
+Analyze the target agent's context to determine appropriate identity, skills, and configuration.
+
+## Analysis Tasks
+
+### 1. Directory Analysis
+
+Examine the agent directory:
+
+- [ ] Read directory name for agent purpose
+- [ ] Check parent directory for organization context
+- [ ] Look for existing ROLE.md or similar documentation
+- [ ] Identify any existing configuration files
+
+### 2. Agent Identity Derivation
+
+From the directory name, derive:
+
+| Component | Source | Example |
+|-----------|--------|---------|
+| Agent Name | Directory name | "Sales Lead Agent" |
+| Organization | Parent directory | "Wayward Guardian" |
+| Persona Name | Generated from type | "Scout" |
+| Agent Type | Keywords in name | "Sales" |
+
+### 3. Role Detection
+
+If ROLE.md exists, extract:
+
+- Role description (first paragraph after title)
+- Key responsibilities (bulleted lists)
+- Domain expertise areas
+- Integration points with other agents
+
+### 4. Existing Files Inventory
+
+Check for files that inform configuration:
+
+| File | Purpose | Action |
+|------|---------|--------|
+| ROLE.md | Role definition | Extract responsibilities |
+| README.md | Documentation | Extract context |
+| .claude/ | Existing infrastructure | Plan upgrade |
+| auto-run/ | Playbooks | Note for integration |
+
+## Agent Profile Template
+
+Based on analysis, build agent profile:
+
+```yaml
+agent:
+  name: "<Agent Name>"
+  persona: "<Short Persona Name>"
+  organization: "<Organization Name>"
+  type: "<Agent Type>"
+
+identity:
+  mission: "<One sentence mission>"
+  role: "<2-3 sentence role description>"
+
+capabilities:
+  primary: []      # Core responsibilities
+  secondary: []    # Supporting tasks
+
+integrations:
+  collaborates_with: []  # Other agents
+  tools: []              # External tools
+```
+
+## Analysis Outputs
+
+Document the following for use in later phases:
+
+1. **Agent Profile** - Complete identity information
+2. **Installation Mode** - Fresh or upgrade
+3. **Customizations Needed** - Based on agent type
+4. **Preservation List** - Files to keep if upgrading
+
+## Type-Specific Considerations
+
+### Technical Agents
+- Include architecture context directories
+- Add development and testing contexts
+- Consider code-related hooks
+
+### Business Agents
+- Include projects context
+- Add working context for active tasks
+- Consider CRM/pipeline integrations
+
+### Research Agents
+- Emphasize knowledge context
+- Add research methodology
+- Consider web search capabilities
+
+### Operations Agents
+- Include process documentation
+- Add tracking and reporting
+- Consider scheduling integrations
+
+## Next Phase
+
+Proceed to **2_PLAN_STRUCTURE.md** to plan the infrastructure structure.

--- a/Setup/Claude-Cognitive-Infrastructure/2_PLAN_STRUCTURE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/2_PLAN_STRUCTURE.md
@@ -1,0 +1,200 @@
+# Phase 2: Plan Structure
+
+## Objective
+
+Plan the complete Claude Cognitive Infrastructure directory structure for the agent.
+
+## Core Directory Structure
+
+```
+<Agent Directory>/
+├── CLAUDE.md                        # Agent identity file
+└── .claude/
+    ├── VERSION                      # Infrastructure version (1.1.0)
+    ├── settings.json                # Hook and behavior settings
+    ├── config/
+    │   └── config.yaml              # Runtime configuration
+    ├── skills/
+    │   └── CORE/
+    │       └── SKILL.md             # Core agent skill
+    ├── context/
+    │   ├── CLAUDE.md                # Context system documentation
+    │   ├── memory/
+    │   │   ├── learnings.md         # Accumulated knowledge
+    │   │   ├── user_preferences.md  # User working style
+    │   │   └── work_status.md       # Current task tracking
+    │   ├── architecture/
+    │   │   └── CLAUDE.md            # Architecture context
+    │   ├── design/
+    │   │   └── CLAUDE.md            # Design principles
+    │   ├── development/
+    │   │   └── CLAUDE.md            # Development context
+    │   ├── projects/
+    │   │   └── CLAUDE.md            # Project configs
+    │   ├── testing/
+    │   │   └── CLAUDE.md            # Testing guidelines
+    │   ├── tools/
+    │   │   └── CLAUDE.md            # Tool documentation
+    │   └── working/
+    │       └── CLAUDE.md            # Working context
+    ├── hooks/
+    │   └── CLAUDE.md                # Hooks documentation
+    ├── agents/
+    │   └── CLAUDE.md                # Agent definitions
+    ├── scripts/
+    │   └── CLAUDE.md                # Utility scripts
+    └── examples/
+        └── CLAUDE.md                # Reference examples
+```
+
+## File Contents Plan
+
+### CLAUDE.md (Root Identity)
+
+```markdown
+# <Agent Name>: <Agent Type>
+
+## Your Name
+Your name is **<Persona>**. You are the <Agent Type> for <Organization>.
+
+## Your Mission
+<Mission statement>
+
+## Your Role
+<Role description>
+
+## Core Responsibilities
+<Grouped responsibilities>
+
+## Memory Management
+**CRITICAL:** Update work_status.md after EVERY conversation turn.
+
+## Organization Context
+<Organization details>
+```
+
+### settings.json
+
+```json
+{
+  "hooks": {
+    "preToolCall": [],
+    "postToolCall": [],
+    "notification": []
+  },
+  "permissions": {
+    "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+  }
+}
+```
+
+### VERSION
+
+```
+1.1.0
+```
+
+### config/config.yaml
+
+```yaml
+version: "1.1.0"
+agent:
+  name: "<Agent Name>"
+  persona: "<Persona>"
+  type: "<Agent Type>"
+settings:
+  memory_update_frequency: "every_turn"
+  context_loading: "progressive"
+```
+
+### CORE/SKILL.md
+
+```markdown
+---
+name: CORE
+version: 1.0.0
+priority: 100
+triggers:
+  - identity
+  - who are you
+  - what do you do
+context_budget: 5000
+---
+
+# <Persona>: Core Identity
+
+## Overview
+<Agent description and capabilities>
+
+## Primary Functions
+<Key responsibilities>
+
+## Working Style
+<How the agent operates>
+```
+
+### Memory Files
+
+**learnings.md:**
+```markdown
+# Learnings
+
+Facts and knowledge accumulated about users, organization, and domain.
+
+## Users
+
+## Organization
+
+## Domain Knowledge
+```
+
+**user_preferences.md:**
+```markdown
+# User Preferences
+
+Working style and preferences for interactions.
+
+## Communication Style
+
+## Working Hours
+
+## Preferences
+```
+
+**work_status.md:**
+```markdown
+# Work Status
+
+Current tasks and progress tracking.
+
+## Active Tasks
+
+## Pending Items
+
+## Recently Completed
+
+---
+*Last updated: <date>*
+```
+
+## Context Placeholder Files
+
+Each context subdirectory gets a CLAUDE.md placeholder:
+
+```markdown
+# <Context Name> Context
+
+This directory contains <context type> information.
+
+## Contents
+
+<Description of what goes here>
+
+## Usage
+
+<How the agent should use this context>
+```
+
+## Next Phase
+
+Proceed to **3_EVALUATE.md** to evaluate the planned structure.

--- a/Setup/Claude-Cognitive-Infrastructure/3_EVALUATE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/3_EVALUATE.md
@@ -1,0 +1,95 @@
+# Phase 3: Evaluate Plan
+
+## Objective
+
+Evaluate the infrastructure plan for completeness, correctness, and safety.
+
+## Evaluation Checklist
+
+### 1. Identity Completeness
+
+- [ ] Agent name is clear and descriptive
+- [ ] Persona name is short and memorable
+- [ ] Mission statement is concise (one sentence)
+- [ ] Role description explains purpose (2-3 sentences)
+- [ ] Responsibilities are specific and actionable
+
+### 2. Structure Completeness
+
+- [ ] All required directories planned
+- [ ] All required files identified
+- [ ] Memory files initialized with proper structure
+- [ ] CORE skill has appropriate triggers
+
+### 3. Configuration Validity
+
+- [ ] settings.json is valid JSON
+- [ ] config.yaml is valid YAML
+- [ ] VERSION file contains valid semver
+- [ ] File paths are correct
+
+### 4. Content Quality
+
+- [ ] CLAUDE.md follows standard template
+- [ ] SKILL.md has valid frontmatter
+- [ ] Memory update instruction is present
+- [ ] Organization context is included
+
+### 5. Safety Checks
+
+- [ ] No existing files will be overwritten without backup
+- [ ] No sensitive data in templates
+- [ ] Permissions are appropriate
+- [ ] No destructive operations planned
+
+## Validation Matrix
+
+| Component | Required | Planned | Valid |
+|-----------|----------|---------|-------|
+| CLAUDE.md | Yes | | |
+| .claude/ | Yes | | |
+| settings.json | Yes | | |
+| VERSION | Yes | | |
+| config/config.yaml | Yes | | |
+| skills/CORE/SKILL.md | Yes | | |
+| context/memory/ | Yes | | |
+| context/CLAUDE.md | Yes | | |
+| hooks/ | Yes | | |
+
+## Risk Assessment
+
+### Low Risk
+- Creating new directories
+- Creating new files in empty locations
+- Adding placeholder CLAUDE.md files
+
+### Medium Risk
+- Overwriting existing CLAUDE.md
+- Modifying existing settings.json
+
+### High Risk (Require Confirmation)
+- Overwriting existing memory files
+- Deleting existing content
+- Modifying existing skills
+
+## Pre-Implementation Checklist
+
+Before proceeding to implementation:
+
+- [ ] All directories identified
+- [ ] All file contents drafted
+- [ ] Agent identity finalized
+- [ ] Backup plan for existing files (if applicable)
+- [ ] No blocking issues identified
+
+## Approval Gate
+
+Implementation can proceed when:
+1. All required components are planned
+2. All content passes validation
+3. No high-risk operations without mitigation
+4. Structure matches infrastructure specification
+
+## Next Phase
+
+If evaluation passes, proceed to **4_IMPLEMENT.md** to execute the installation.

--- a/Setup/Claude-Cognitive-Infrastructure/4_IMPLEMENT.md
+++ b/Setup/Claude-Cognitive-Infrastructure/4_IMPLEMENT.md
@@ -1,0 +1,278 @@
+# Phase 4: Implement Installation
+
+## Objective
+
+Execute the Claude Cognitive Infrastructure installation.
+
+## Implementation Steps
+
+### Step 1: Create Directory Structure
+
+Create the `.claude/` directory tree:
+
+```bash
+mkdir -p .claude/{config,skills/CORE,context/{memory,architecture,design,development,projects,testing,tools,working},hooks,agents,scripts,examples}
+```
+
+### Step 2: Create VERSION File
+
+```bash
+echo "1.1.0" > .claude/VERSION
+```
+
+### Step 3: Create settings.json
+
+Create `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "preToolCall": [],
+    "postToolCall": [],
+    "notification": []
+  },
+  "permissions": {
+    "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"]
+  },
+  "memory": {
+    "updateFrequency": "every_turn",
+    "autoSave": true
+  }
+}
+```
+
+### Step 4: Create config.yaml
+
+Create `.claude/config/config.yaml`:
+
+```yaml
+version: "1.1.0"
+infrastructure:
+  name: "Claude Cognitive Infrastructure"
+  installed: "<current-date>"
+
+agent:
+  name: "<Agent Name>"
+  persona: "<Persona>"
+  type: "<Agent Type>"
+  organization: "<Organization>"
+
+settings:
+  memory_update_frequency: "every_turn"
+  context_loading: "progressive"
+  skill_activation: "trigger_based"
+
+capabilities:
+  memory: true
+  skills: true
+  hooks: true
+  context: true
+```
+
+### Step 5: Create CLAUDE.md (Root Identity)
+
+Create `CLAUDE.md` in agent root:
+
+```markdown
+# <Agent Name>: <Agent Type>
+
+## Your Name
+
+Your name is **<Persona>**. You are the <Agent Type> for <Organization>.
+
+## Your Mission
+
+<Mission statement - one clear sentence describing purpose>
+
+## Your Role
+
+<Role description - 2-3 sentences on how this agent fits in the organization>
+
+## Core Responsibilities
+
+### Primary Functions
+- <Key responsibility 1>
+- <Key responsibility 2>
+- <Key responsibility 3>
+
+### Supporting Tasks
+- <Supporting task 1>
+- <Supporting task 2>
+
+## Context System
+
+You have access to a context system at `.claude/context/`:
+
+- **Memory** (`.claude/context/memory/`): Persistent knowledge
+  - `learnings.md` - Facts about users and organization
+  - `user_preferences.md` - Working preferences and style
+  - `work_status.md` - Current tasks and progress
+
+## Memory Management
+
+**CRITICAL:** Update `work_status.md` after EVERY conversation turn to maintain continuity.
+
+- Read relevant memories before starting work
+- Update memories after significant interactions
+- Keep work status current
+
+## Organization Context
+
+<Organization description and relevant context>
+
+---
+
+*Claude Cognitive Infrastructure v1.1.0*
+```
+
+### Step 6: Create CORE Skill
+
+Create `.claude/skills/CORE/SKILL.md`:
+
+```markdown
+---
+name: CORE
+version: 1.0.0
+priority: 100
+triggers:
+  - identity
+  - who are you
+  - what do you do
+  - help
+  - capabilities
+context_budget: 5000
+---
+
+# <Persona>: Core Identity
+
+## Overview
+
+I am **<Persona>**, the <Agent Type> for <Organization>. <Brief description of capabilities and purpose>.
+
+## Primary Functions
+
+<List of key responsibilities>
+
+## Working Style
+
+<Description of how the agent operates, communicates, and approaches tasks>
+
+## Available Capabilities
+
+- **Memory**: Persistent knowledge across sessions
+- **Skills**: Modular domain expertise
+- **Context**: Structured knowledge by domain
+- **Hooks**: Event-driven automation
+
+---
+
+*Core Identity Skill v1.0.0*
+```
+
+### Step 7: Initialize Memory Files
+
+Create `.claude/context/memory/learnings.md`:
+
+```markdown
+# Learnings
+
+Facts and knowledge accumulated about users, organization, and domain.
+
+## Users
+
+<!-- Add user-specific learnings here -->
+
+## Organization
+
+<!-- Add organization learnings here -->
+
+## Domain Knowledge
+
+<!-- Add domain-specific learnings here -->
+
+---
+*Last updated: <date>*
+```
+
+Create `.claude/context/memory/user_preferences.md`:
+
+```markdown
+# User Preferences
+
+Working style and preferences for interactions.
+
+## Communication Style
+
+<!-- Preferred communication approach -->
+
+## Working Hours
+
+<!-- Typical availability -->
+
+## Preferences
+
+<!-- Specific preferences noted -->
+
+---
+*Last updated: <date>*
+```
+
+Create `.claude/context/memory/work_status.md`:
+
+```markdown
+# Work Status
+
+Current tasks and progress tracking.
+
+## Active Tasks
+
+<!-- Currently in-progress work -->
+
+## Pending Items
+
+<!-- Queued for future -->
+
+## Recently Completed
+
+<!-- Finished within last session -->
+
+---
+*Last updated: <date>*
+```
+
+### Step 8: Create Context Placeholders
+
+Create CLAUDE.md in each context subdirectory with appropriate documentation for that context type.
+
+### Step 9: Create Hooks Placeholder
+
+Create `.claude/hooks/CLAUDE.md`:
+
+```markdown
+# Hooks
+
+Event-driven automation hooks for the agent.
+
+## Available Hook Points
+
+- **preToolCall**: Before tool execution
+- **postToolCall**: After tool execution
+- **notification**: For alerts and updates
+
+## Adding Hooks
+
+Create TypeScript files in this directory to add hook functionality.
+```
+
+## Post-Implementation
+
+After all files are created:
+
+1. Verify file permissions
+2. Validate JSON/YAML syntax
+3. Confirm all directories exist
+4. Test basic functionality
+
+## Next Phase
+
+Proceed to **5_VERIFY.md** to verify the installation.

--- a/Setup/Claude-Cognitive-Infrastructure/5_VERIFY.md
+++ b/Setup/Claude-Cognitive-Infrastructure/5_VERIFY.md
@@ -1,0 +1,144 @@
+# Phase 5: Verify Installation
+
+## Objective
+
+Verify the Claude Cognitive Infrastructure is correctly installed and functional.
+
+## Verification Checklist
+
+### 1. Directory Structure
+
+Verify all directories exist:
+
+- [ ] `.claude/` directory exists
+- [ ] `.claude/config/` exists
+- [ ] `.claude/skills/CORE/` exists
+- [ ] `.claude/context/` exists
+- [ ] `.claude/context/memory/` exists
+- [ ] `.claude/hooks/` exists
+- [ ] `.claude/agents/` exists
+- [ ] `.claude/scripts/` exists
+- [ ] `.claude/examples/` exists
+
+### 2. Core Files
+
+Verify essential files are in place:
+
+- [ ] `CLAUDE.md` exists in agent root
+- [ ] `.claude/VERSION` contains "1.1.0"
+- [ ] `.claude/settings.json` exists and is valid JSON
+- [ ] `.claude/config/config.yaml` exists and is valid YAML
+- [ ] `.claude/skills/CORE/SKILL.md` exists
+
+### 3. Memory System
+
+Verify memory files:
+
+- [ ] `.claude/context/memory/learnings.md` exists
+- [ ] `.claude/context/memory/user_preferences.md` exists
+- [ ] `.claude/context/memory/work_status.md` exists
+
+### 4. Content Validation
+
+#### CLAUDE.md
+- [ ] Contains agent name
+- [ ] Contains persona name
+- [ ] Contains mission statement
+- [ ] Contains role description
+- [ ] Contains memory management instructions
+- [ ] Contains "Update work_status.md after EVERY conversation turn"
+
+#### settings.json
+- [ ] Valid JSON syntax
+- [ ] Contains hooks configuration
+- [ ] Contains permissions
+
+#### CORE/SKILL.md
+- [ ] Valid YAML frontmatter
+- [ ] Contains triggers
+- [ ] Has priority of 100
+- [ ] Has context_budget defined
+
+## Functional Testing
+
+### Test 1: Identity Check
+Ask the agent: "Who are you?"
+
+**Expected**: Agent should respond with its persona name, role, and purpose.
+
+### Test 2: Memory Access
+Ask the agent: "What's in your work status?"
+
+**Expected**: Agent should read and report from `.claude/context/memory/work_status.md`.
+
+### Test 3: Memory Update
+Ask the agent to add a task to work status.
+
+**Expected**: Agent should update `.claude/context/memory/work_status.md`.
+
+### Test 4: Skill Activation
+Ask: "What can you do?"
+
+**Expected**: Agent should describe its capabilities based on CORE skill.
+
+## Success Criteria
+
+Installation is successful when:
+
+1. All directories exist
+2. All core files are present
+3. Files contain valid content
+4. Agent responds correctly to identity queries
+5. Memory read/write operations work
+
+## Troubleshooting
+
+### Missing Directories
+Re-run the mkdir command from Step 1 of implementation.
+
+### Invalid JSON/YAML
+Check for syntax errors:
+- Trailing commas in JSON
+- Incorrect indentation in YAML
+- Missing quotes around strings
+
+### Identity Not Loading
+- Verify CLAUDE.md is in agent root (not in .claude/)
+- Check file permissions
+- Ensure no syntax errors in markdown
+
+### Memory Not Updating
+- Verify memory directory exists
+- Check file permissions
+- Ensure files are not locked
+
+## Post-Verification
+
+Once verification passes:
+
+1. **Document completion** - Note installation date in config.yaml
+2. **Test knowledge packs** - Ready to install additional knowledge packs
+3. **Customize as needed** - Add agent-specific context and skills
+
+## Installation Complete
+
+The Claude Cognitive Infrastructure is now installed and operational.
+
+The agent has:
+- Persistent memory across sessions
+- Modular skill system
+- Structured context management
+- Event-driven hooks capability
+- Complete identity configuration
+
+### Next Steps
+
+1. Run **Knowledge Pack** playbooks to add domain expertise
+2. Customize CLAUDE.md with additional instructions
+3. Add custom hooks for automation
+4. Begin using the agent
+
+---
+
+*Claude Cognitive Infrastructure v1.1.0*
+*Installation Verified: <date>*

--- a/Setup/Claude-Cognitive-Infrastructure/README.md
+++ b/Setup/Claude-Cognitive-Infrastructure/README.md
@@ -1,0 +1,84 @@
+# Claude Cognitive Infrastructure Setup
+
+Deploys the complete Claude Cognitive Infrastructure to any agent directory, enabling persistent memory, modular skills, context management, and event-driven hooks.
+
+## What This Playbook Does
+
+This playbook creates the foundational `.claude/` directory structure that gives Claude-based agents their cognitive capabilities:
+
+- **Memory System** - Persistent knowledge across sessions (learnings, preferences, work status)
+- **Skills Framework** - Modular domain expertise that activates based on intent
+- **Context Management** - Structured knowledge organized by domain
+- **Hooks System** - Event-driven automation for observability
+- **Configuration** - Settings and config files for customization
+
+## Infrastructure Structure
+
+After running this playbook, the agent will have:
+
+```
+Agent Directory/
+├── CLAUDE.md                    # Agent identity (single source of truth)
+└── .claude/
+    ├── settings.json            # Hook configuration
+    ├── VERSION                  # Infrastructure version tracking
+    ├── config/
+    │   └── config.yaml          # Runtime settings
+    ├── skills/
+    │   └── CORE/
+    │       └── SKILL.md         # Core skill with agent identity
+    ├── context/
+    │   ├── CLAUDE.md            # Context system documentation
+    │   ├── memory/              # Persistent memory
+    │   │   ├── learnings.md     # Facts about users/org
+    │   │   ├── user_preferences.md  # Working style
+    │   │   └── work_status.md   # Current tasks
+    │   ├── architecture/        # System design patterns
+    │   ├── design/              # Design principles
+    │   ├── development/         # Development context
+    │   ├── projects/            # Project-specific configs
+    │   ├── testing/             # Testing guidelines
+    │   ├── tools/               # Tool documentation
+    │   └── working/             # Working context
+    ├── hooks/                   # TypeScript event hooks
+    ├── agents/                  # Orchestration worker definitions
+    ├── scripts/                 # Utility scripts
+    └── examples/                # Reference examples
+```
+
+## Prerequisites
+
+- An agent directory where you want to install the infrastructure
+- The agent should have a clear purpose/role (used to generate identity)
+
+## Usage
+
+Run this playbook in the target agent's directory. The playbook will:
+
+1. Analyze the agent's purpose from directory name and any existing files
+2. Generate appropriate agent identity (name, mission, role)
+3. Create the complete `.claude/` directory structure
+4. Initialize memory files
+5. Create the CORE skill with agent identity
+6. Verify the installation
+
+## After Installation
+
+Once the infrastructure is installed, you can:
+
+1. Run **Knowledge Pack** playbooks to add domain expertise
+2. Customize the CLAUDE.md with additional instructions
+3. Add custom hooks for automation
+4. Start using the agent with full cognitive capabilities
+
+## Version
+
+Current infrastructure version: **1.1.0**
+
+## Credits
+
+The Claude Cognitive Infrastructure was influenced by [Daniel Miessler's](https://danielmiessler.com/) [Personal AI Infrastructure](https://github.com/danielmiessler/Personal_AI_Infrastructure) project, which pioneered many of the concepts around persistent memory, modular skills, and structured context for AI assistants.
+
+---
+
+*Claude Cognitive Infrastructure Setup Playbook*


### PR DESCRIPTION
## Summary

Adds the foundational Claude Cognitive Infrastructure setup playbook that was missing from the Setup category.

This playbook creates the base `.claude/` directory structure that enables agents with:
- **Persistent memory system** (learnings, preferences, work status)
- **Modular skills framework** with CORE identity skill
- **Structured context management** by domain
- **Event-driven hooks** capability
- **Complete agent identity** configuration

## Why This Is Needed

The Knowledge Packs added in the previous PR (#X) are designed to be installed **on top of** existing Claude Cognitive Infrastructure. However, there was no playbook to create that base infrastructure - only a shell script existed in a separate repo.

This playbook converts that functionality to the standard 6-document Maestro format.

## Files Added

- `Setup/Claude-Cognitive-Infrastructure/README.md`
- `Setup/Claude-Cognitive-Infrastructure/0_INITIALIZE.md`
- `Setup/Claude-Cognitive-Infrastructure/1_ANALYZE.md`
- `Setup/Claude-Cognitive-Infrastructure/2_PLAN_STRUCTURE.md`
- `Setup/Claude-Cognitive-Infrastructure/3_EVALUATE.md`
- `Setup/Claude-Cognitive-Infrastructure/4_IMPLEMENT.md`
- `Setup/Claude-Cognitive-Infrastructure/5_VERIFY.md`

## Usage Order

1. Run **Claude-Cognitive-Infrastructure** playbook first (this PR)
2. Then run **Knowledge Pack** playbooks to add domain expertise

🤖 Generated with [Claude Code](https://claude.com/claude-code)