### PR TITLE
Add Claude Cognitive Infrastructure and Knowledge Packs

### DIFF
--- a/Setup/Claude-Cognitive-Infrastructure/0_INITIALIZE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/0_INITIALIZE.md
@@ -1,0 +1,74 @@
+# Phase 0: Initialize
+
+## Objective
+
+Validate prerequisites and prepare for Claude Cognitive Infrastructure deployment.
+
+## Prerequisites Checklist
+
+### 1. Target Directory
+
+Verify the target agent directory:
+
+- [ ] Agent directory exists and is writable
+- [ ] Directory has a clear name indicating agent purpose
+- [ ] No critical files will be overwritten (or backup is acceptable)
+
+### 2. Existing Infrastructure Check
+
+Check for existing `.claude/` directory:
+
+- [ ] If `.claude/` exists, determine upgrade vs fresh install
+- [ ] If upgrading, backup existing memory files
+- [ ] Note any custom configurations to preserve
+
+### 3. Agent Context
+
+Gather information about the agent:
+
+- [ ] Agent name (from directory name)
+- [ ] Organization (from parent directory, if applicable)
+- [ ] Agent type/role (inferred from name or existing files)
+
+## Agent Type Detection
+
+Based on directory name, detect agent type for customization:
+
+| Keywords in Name | Agent Type | Persona Suggestion |
+|------------------|------------|-------------------|
+| Sales, Lead, Pipeline | Sales | Scout |
+| Engineer, Architect, Developer | Technical | Archon |
+| Research, Analysis | Research | Sage |
+| Marketing, Content | Marketing | Maven |
+| Fundraising, Investor | Finance | Catalyst |
+| Operations, Admin | Operations | Atlas |
+| People, Recruiting, HR | People | Harbor |
+| Executive, Chief | Executive | Aria |
+| Brand, Communications | Communications | Echo |
+| Strategy, Planning | Strategy | Compass |
+| Customer, Success | Customer | Bridge |
+| UX, Design | Design | Pixel |
+
+## Validation Steps
+
+1. Confirm agent directory path
+2. Check write permissions
+3. Detect agent type from name
+4. Check for existing infrastructure
+5. Determine installation mode (fresh/upgrade)
+
+## Installation Modes
+
+### Fresh Install
+- Create complete `.claude/` structure
+- Generate new CLAUDE.md identity
+- Initialize empty memory files
+
+### Upgrade Install
+- Preserve existing memory files
+- Update structure to latest version
+- Add new capabilities (hooks, skills)
+
+## Next Phase
+
+Once prerequisites are validated, proceed to **1_ANALYZE.md** to analyze the agent context.

--- a/Setup/Claude-Cognitive-Infrastructure/1_ANALYZE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/1_ANALYZE.md
@@ -1,0 +1,106 @@
+# Phase 1: Analyze Agent Context
+
+## Objective
+
+Analyze the target agent's context to determine appropriate identity, skills, and configuration.
+
+## Analysis Tasks
+
+### 1. Directory Analysis
+
+Examine the agent directory:
+
+- [ ] Read directory name for agent purpose
+- [ ] Check parent directory for organization context
+- [ ] Look for existing ROLE.md or similar documentation
+- [ ] Identify any existing configuration files
+
+### 2. Agent Identity Derivation
+
+From the directory name, derive:
+
+| Component | Source | Example |
+|-----------|--------|---------|
+| Agent Name | Directory name | "Sales Lead Agent" |
+| Organization | Parent directory | "Wayward Guardian" |
+| Persona Name | Generated from type | "Scout" |
+| Agent Type | Keywords in name | "Sales" |
+
+### 3. Role Detection
+
+If ROLE.md exists, extract:
+
+- Role description (first paragraph after title)
+- Key responsibilities (bulleted lists)
+- Domain expertise areas
+- Integration points with other agents
+
+### 4. Existing Files Inventory
+
+Check for files that inform configuration:
+
+| File | Purpose | Action |
+|------|---------|--------|
+| ROLE.md | Role definition | Extract responsibilities |
+| README.md | Documentation | Extract context |
+| .claude/ | Existing infrastructure | Plan upgrade |
+| auto-run/ | Playbooks | Note for integration |
+
+## Agent Profile Template
+
+Based on analysis, build agent profile:
+
+```yaml
+agent:
+  name: "<Agent Name>"
+  persona: "<Short Persona Name>"
+  organization: "<Organization Name>"
+  type: "<Agent Type>"
+
+identity:
+  mission: "<One sentence mission>"
+  role: "<2-3 sentence role description>"
+
+capabilities:
+  primary: []      # Core responsibilities
+  secondary: []    # Supporting tasks
+
+integrations:
+  collaborates_with: []  # Other agents
+  tools: []              # External tools
+```
+
+## Analysis Outputs
+
+Document the following for use in later phases:
+
+1. **Agent Profile** - Complete identity information
+2. **Installation Mode** - Fresh or upgrade
+3. **Customizations Needed** - Based on agent type
+4. **Preservation List** - Files to keep if upgrading
+
+## Type-Specific Considerations
+
+### Technical Agents
+- Include architecture context directories
+- Add development and testing contexts
+- Consider code-related hooks
+
+### Business Agents
+- Include projects context
+- Add working context for active tasks
+- Consider CRM/pipeline integrations
+
+### Research Agents
+- Emphasize knowledge context
+- Add research methodology
+- Consider web search capabilities
+
+### Operations Agents
+- Include process documentation
+- Add tracking and reporting
+- Consider scheduling integrations
+
+## Next Phase
+
+Proceed to **2_PLAN_STRUCTURE.md** to plan the infrastructure structure.

--- a/Setup/Claude-Cognitive-Infrastructure/2_PLAN_STRUCTURE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/2_PLAN_STRUCTURE.md
@@ -1,0 +1,200 @@
+# Phase 2: Plan Structure
+
+## Objective
+
+Plan the complete Claude Cognitive Infrastructure directory structure for the agent.
+
+## Core Directory Structure
+
+```
+<Agent Directory>/
+├── CLAUDE.md                        # Agent identity file
+└── .claude/
+    ├── VERSION                      # Infrastructure version (1.1.0)
+    ├── settings.json                # Hook and behavior settings
+    ├── config/
+    │   └── config.yaml              # Runtime configuration
+    ├── skills/
+    │   └── CORE/
+    │       └── SKILL.md             # Core agent skill
+    ├── context/
+    │   ├── CLAUDE.md                # Context system documentation
+    │   ├── memory/
+    │   │   ├── learnings.md         # Accumulated knowledge
+    │   │   ├── user_preferences.md  # User working style
+    │   │   └── work_status.md       # Current task tracking
+    │   ├── architecture/
+    │   │   └── CLAUDE.md            # Architecture context
+    │   ├── design/
+    │   │   └── CLAUDE.md            # Design principles
+    │   ├── development/
+    │   │   └── CLAUDE.md            # Development context
+    │   ├── projects/
+    │   │   └── CLAUDE.md            # Project configs
+    │   ├── testing/
+    │   │   └── CLAUDE.md            # Testing guidelines
+    │   ├── tools/
+    │   │   └── CLAUDE.md            # Tool documentation
+    │   └── working/
+    │       └── CLAUDE.md            # Working context
+    ├── hooks/
+    │   └── CLAUDE.md                # Hooks documentation
+    ├── agents/
+    │   └── CLAUDE.md                # Agent definitions
+    ├── scripts/
+    │   └── CLAUDE.md                # Utility scripts
+    └── examples/
+        └── CLAUDE.md                # Reference examples
+```
+
+## File Contents Plan
+
+### CLAUDE.md (Root Identity)
+
+```markdown
+# <Agent Name>: <Agent Type>
+
+## Your Name
+Your name is **<Persona>**. You are the <Agent Type> for <Organization>.
+
+## Your Mission
+<Mission statement>
+
+## Your Role
+<Role description>
+
+## Core Responsibilities
+<Grouped responsibilities>
+
+## Memory Management
+**CRITICAL:** Update work_status.md after EVERY conversation turn.
+
+## Organization Context
+<Organization details>
+```
+
+### settings.json
+
+```json
+{
+  "hooks": {
+    "preToolCall": [],
+    "postToolCall": [],
+    "notification": []
+  },
+  "permissions": {
+    "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep"]
+  }
+}
+```
+
+### VERSION
+
+```
+1.1.0
+```
+
+### config/config.yaml
+
+```yaml
+version: "1.1.0"
+agent:
+  name: "<Agent Name>"
+  persona: "<Persona>"
+  type: "<Agent Type>"
+settings:
+  memory_update_frequency: "every_turn"
+  context_loading: "progressive"
+```
+
+### CORE/SKILL.md
+
+```markdown
+---
+name: CORE
+version: 1.0.0
+priority: 100
+triggers:
+  - identity
+  - who are you
+  - what do you do
+context_budget: 5000
+---
+
+# <Persona>: Core Identity
+
+## Overview
+<Agent description and capabilities>
+
+## Primary Functions
+<Key responsibilities>
+
+## Working Style
+<How the agent operates>
+```
+
+### Memory Files
+
+**learnings.md:**
+```markdown
+# Learnings
+
+Facts and knowledge accumulated about users, organization, and domain.
+
+## Users
+
+## Organization
+
+## Domain Knowledge
+```
+
+**user_preferences.md:**
+```markdown
+# User Preferences
+
+Working style and preferences for interactions.
+
+## Communication Style
+
+## Working Hours
+
+## Preferences
+```
+
+**work_status.md:**
+```markdown
+# Work Status
+
+Current tasks and progress tracking.
+
+## Active Tasks
+
+## Pending Items
+
+## Recently Completed
+
+---
+*Last updated: <date>*
+```
+
+## Context Placeholder Files
+
+Each context subdirectory gets a CLAUDE.md placeholder:
+
+```markdown
+# <Context Name> Context
+
+This directory contains <context type> information.
+
+## Contents
+
+<Description of what goes here>
+
+## Usage
+
+<How the agent should use this context>
+```
+
+## Next Phase
+
+Proceed to **3_EVALUATE.md** to evaluate the planned structure.

--- a/Setup/Claude-Cognitive-Infrastructure/3_EVALUATE.md
+++ b/Setup/Claude-Cognitive-Infrastructure/3_EVALUATE.md
@@ -1,0 +1,95 @@
+# Phase 3: Evaluate Plan
+
+## Objective
+
+Evaluate the infrastructure plan for completeness, correctness, and safety.
+
+## Evaluation Checklist
+
+### 1. Identity Completeness
+
+- [ ] Agent name is clear and descriptive
+- [ ] Persona name is short and memorable
+- [ ] Mission statement is concise (one sentence)
+- [ ] Role description explains purpose (2-3 sentences)
+- [ ] Responsibilities are specific and actionable
+
+### 2. Structure Completeness
+
+- [ ] All required directories planned
+- [ ] All required files identified
+- [ ] Memory files initialized with proper structure
+- [ ] CORE skill has appropriate triggers
+
+### 3. Configuration Validity
+
+- [ ] settings.json is valid JSON
+- [ ] config.yaml is valid YAML
+- [ ] VERSION file contains valid semver
+- [ ] File paths are correct
+
+### 4. Content Quality
+
+- [ ] CLAUDE.md follows standard template
+- [ ] SKILL.md has valid frontmatter
+- [ ] Memory update instruction is present
+- [ ] Organization context is included
+
+### 5. Safety Checks
+
+- [ ] No existing files will be overwritten without backup
+- [ ] No sensitive data in templates
+- [ ] Permissions are appropriate
+- [ ] No destructive operations planned
+
+## Validation Matrix
+
+| Component | Required | Planned | Valid |
+|-----------|----------|---------|-------|
+| CLAUDE.md | Yes | | |
+| .claude/ | Yes | | |
+| settings.json | Yes | | |
+| VERSION | Yes | | |
+| config/config.yaml | Yes | | |
+| skills/CORE/SKILL.md | Yes | | |
+| context/memory/ | Yes | | |
+| context/CLAUDE.md | Yes | | |
+| hooks/ | Yes | | |
+
+## Risk Assessment
+
+### Low Risk
+- Creating new directories
+- Creating new files in empty locations
+- Adding placeholder CLAUDE.md files
+
+### Medium Risk
+- Overwriting existing CLAUDE.md
+- Modifying existing settings.json
+
+### High Risk (Require Confirmation)
+- Overwriting existing memory files
+- Deleting existing content
+- Modifying existing skills
+
+## Pre-Implementation Checklist
+
+Before proceeding to implementation:
+
+- [ ] All directories identified
+- [ ] All file contents drafted
+- [ ] Agent identity finalized
+- [ ] Backup plan for existing files (if applicable)
+- [ ] No blocking issues identified
+
+## Approval Gate
+
+Implementation can proceed when:
+1. All required components are planned
+2. All content passes validation
+3. No high-risk operations without mitigation
+4. Structure matches infrastructure specification
+
+## Next Phase
+
+If evaluation passes, proceed to **4_IMPLEMENT.md** to execute the installation.

--- a/Setup/Claude-Cognitive-Infrastructure/4_IMPLEMENT.md
+++ b/Setup/Claude-Cognitive-Infrastructure/4_IMPLEMENT.md
@@ -1,0 +1,278 @@
+# Phase 4: Implement Installation
+
+## Objective
+
+Execute the Claude Cognitive Infrastructure installation.
+
+## Implementation Steps
+
+### Step 1: Create Directory Structure
+
+Create the `.claude/` directory tree:
+
+```bash
+mkdir -p .claude/{config,skills/CORE,context/{memory,architecture,design,development,projects,testing,tools,working},hooks,agents,scripts,examples}
+```
+
+### Step 2: Create VERSION File
+
+```bash
+echo "1.1.0" > .claude/VERSION
+```
+
+### Step 3: Create settings.json
+
+Create `.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "preToolCall": [],
+    "postToolCall": [],
+    "notification": []
+  },
+  "permissions": {
+    "tools": ["Read", "Write", "Edit", "Bash", "Glob", "Grep", "WebFetch", "WebSearch"]
+  },
+  "memory": {
+    "updateFrequency": "every_turn",
+    "autoSave": true
+  }
+}
+```
+
+### Step 4: Create config.yaml
+
+Create `.claude/config/config.yaml`:
+
+```yaml
+version: "1.1.0"
+infrastructure:
+  name: "Claude Cognitive Infrastructure"
+  installed: "<current-date>"
+
+agent:
+  name: "<Agent Name>"
+  persona: "<Persona>"
+  type: "<Agent Type>"
+  organization: "<Organization>"
+
+settings:
+  memory_update_frequency: "every_turn"
+  context_loading: "progressive"
+  skill_activation: "trigger_based"
+
+capabilities:
+  memory: true
+  skills: true
+  hooks: true
+  context: true
+```
+
+### Step 5: Create CLAUDE.md (Root Identity)
+
+Create `CLAUDE.md` in agent root:
+
+```markdown
+# <Agent Name>: <Agent Type>
+
+## Your Name
+
+Your name is **<Persona>**. You are the <Agent Type> for <Organization>.
+
+## Your Mission
+
+<Mission statement - one clear sentence describing purpose>
+
+## Your Role
+
+<Role description - 2-3 sentences on how this agent fits in the organization>
+
+## Core Responsibilities
+
+### Primary Functions
+- <Key responsibility 1>
+- <Key responsibility 2>
+- <Key responsibility 3>
+
+### Supporting Tasks
+- <Supporting task 1>
+- <Supporting task 2>
+
+## Context System
+
+You have access to a context system at `.claude/context/`:
+
+- **Memory** (`.claude/context/memory/`): Persistent knowledge
+  - `learnings.md` - Facts about users and organization
+  - `user_preferences.md` - Working preferences and style
+  - `work_status.md` - Current tasks and progress
+
+## Memory Management
+
+**CRITICAL:** Update `work_status.md` after EVERY conversation turn to maintain continuity.
+
+- Read relevant memories before starting work
+- Update memories after significant interactions
+- Keep work status current
+
+## Organization Context
+
+<Organization description and relevant context>
+
+---
+
+*Claude Cognitive Infrastructure v1.1.0*
+```
+
+### Step 6: Create CORE Skill
+
+Create `.claude/skills/CORE/SKILL.md`:
+
+```markdown
+---
+name: CORE
+version: 1.0.0
+priority: 100
+triggers:
+  - identity
+  - who are you
+  - what do you do
+  - help
+  - capabilities
+context_budget: 5000
+---
+
+# <Persona>: Core Identity
+
+## Overview
+
+I am **<Persona>**, the <Agent Type> for <Organization>. <Brief description of capabilities and purpose>.
+
+## Primary Functions
+
+<List of key responsibilities>
+
+## Working Style
+
+<Description of how the agent operates, communicates, and approaches tasks>
+
+## Available Capabilities
+
+- **Memory**: Persistent knowledge across sessions
+- **Skills**: Modular domain expertise
+- **Context**: Structured knowledge by domain
+- **Hooks**: Event-driven automation
+
+---
+
+*Core Identity Skill v1.0.0*
+```
+
+### Step 7: Initialize Memory Files
+
+Create `.claude/context/memory/learnings.md`:
+
+```markdown
+# Learnings
+
+Facts and knowledge accumulated about users, organization, and domain.
+
+## Users
+
+<!-- Add user-specific learnings here -->
+
+## Organization
+
+<!-- Add organization learnings here -->
+
+## Domain Knowledge
+
+<!-- Add domain-specific learnings here -->
+
+---
+*Last updated: <date>*
+```
+
+Create `.claude/context/memory/user_preferences.md`:
+
+```markdown
+# User Preferences
+
+Working style and preferences for interactions.
+
+## Communication Style
+
+<!-- Preferred communication approach -->
+
+## Working Hours
+
+<!-- Typical availability -->
+
+## Preferences
+
+<!-- Specific preferences noted -->
+
+---
+*Last updated: <date>*
+```
+
+Create `.claude/context/memory/work_status.md`:
+
+```markdown
+# Work Status
+
+Current tasks and progress tracking.
+
+## Active Tasks
+
+<!-- Currently in-progress work -->
+
+## Pending Items
+
+<!-- Queued for future -->
+
+## Recently Completed
+
+<!-- Finished within last session -->
+
+---
+*Last updated: <date>*
+```
+
+### Step 8: Create Context Placeholders
+
+Create CLAUDE.md in each context subdirectory with appropriate documentation for that context type.
+
+### Step 9: Create Hooks Placeholder
+
+Create `.claude/hooks/CLAUDE.md`:
+
+```markdown
+# Hooks
+
+Event-driven automation hooks for the agent.
+
+## Available Hook Points
+
+- **preToolCall**: Before tool execution
+- **postToolCall**: After tool execution
+- **notification**: For alerts and updates
+
+## Adding Hooks
+
+Create TypeScript files in this directory to add hook functionality.
+```
+
+## Post-Implementation
+
+After all files are created:
+
+1. Verify file permissions
+2. Validate JSON/YAML syntax
+3. Confirm all directories exist
+4. Test basic functionality
+
+## Next Phase
+
+Proceed to **5_VERIFY.md** to verify the installation.

--- a/Setup/Claude-Cognitive-Infrastructure/5_VERIFY.md
+++ b/Setup/Claude-Cognitive-Infrastructure/5_VERIFY.md
@@ -1,0 +1,144 @@
+# Phase 5: Verify Installation
+
+## Objective
+
+Verify the Claude Cognitive Infrastructure is correctly installed and functional.
+
+## Verification Checklist
+
+### 1. Directory Structure
+
+Verify all directories exist:
+
+- [ ] `.claude/` directory exists
+- [ ] `.claude/config/` exists
+- [ ] `.claude/skills/CORE/` exists
+- [ ] `.claude/context/` exists
+- [ ] `.claude/context/memory/` exists
+- [ ] `.claude/hooks/` exists
+- [ ] `.claude/agents/` exists
+- [ ] `.claude/scripts/` exists
+- [ ] `.claude/examples/` exists
+
+### 2. Core Files
+
+Verify essential files are in place:
+
+- [ ] `CLAUDE.md` exists in agent root
+- [ ] `.claude/VERSION` contains "1.1.0"
+- [ ] `.claude/settings.json` exists and is valid JSON
+- [ ] `.claude/config/config.yaml` exists and is valid YAML
+- [ ] `.claude/skills/CORE/SKILL.md` exists
+
+### 3. Memory System
+
+Verify memory files:
+
+- [ ] `.claude/context/memory/learnings.md` exists
+- [ ] `.claude/context/memory/user_preferences.md` exists
+- [ ] `.claude/context/memory/work_status.md` exists
+
+### 4. Content Validation
+
+#### CLAUDE.md
+- [ ] Contains agent name
+- [ ] Contains persona name
+- [ ] Contains mission statement
+- [ ] Contains role description
+- [ ] Contains memory management instructions
+- [ ] Contains "Update work_status.md after EVERY conversation turn"
+
+#### settings.json
+- [ ] Valid JSON syntax
+- [ ] Contains hooks configuration
+- [ ] Contains permissions
+
+#### CORE/SKILL.md
+- [ ] Valid YAML frontmatter
+- [ ] Contains triggers
+- [ ] Has priority of 100
+- [ ] Has context_budget defined
+
+## Functional Testing
+
+### Test 1: Identity Check
+Ask the agent: "Who are you?"
+
+**Expected**: Agent should respond with its persona name, role, and purpose.
+
+### Test 2: Memory Access
+Ask the agent: "What's in your work status?"
+
+**Expected**: Agent should read and report from `.claude/context/memory/work_status.md`.
+
+### Test 3: Memory Update
+Ask the agent to add a task to work status.
+
+**Expected**: Agent should update `.claude/context/memory/work_status.md`.
+
+### Test 4: Skill Activation
+Ask: "What can you do?"
+
+**Expected**: Agent should describe its capabilities based on CORE skill.
+
+## Success Criteria
+
+Installation is successful when:
+
+1. All directories exist
+2. All core files are present
+3. Files contain valid content
+4. Agent responds correctly to identity queries
+5. Memory read/write operations work
+
+## Troubleshooting
+
+### Missing Directories
+Re-run the mkdir command from Step 1 of implementation.
+
+### Invalid JSON/YAML
+Check for syntax errors:
+- Trailing commas in JSON
+- Incorrect indentation in YAML
+- Missing quotes around strings
+
+### Identity Not Loading
+- Verify CLAUDE.md is in agent root (not in .claude/)
+- Check file permissions
+- Ensure no syntax errors in markdown
+
+### Memory Not Updating
+- Verify memory directory exists
+- Check file permissions
+- Ensure files are not locked
+
+## Post-Verification
+
+Once verification passes:
+
+1. **Document completion** - Note installation date in config.yaml
+2. **Test knowledge packs** - Ready to install additional knowledge packs
+3. **Customize as needed** - Add agent-specific context and skills
+
+## Installation Complete
+
+The Claude Cognitive Infrastructure is now installed and operational.
+
+The agent has:
+- Persistent memory across sessions
+- Modular skill system
+- Structured context management
+- Event-driven hooks capability
+- Complete identity configuration
+
+### Next Steps
+
+1. Run **Knowledge Pack** playbooks to add domain expertise
+2. Customize CLAUDE.md with additional instructions
+3. Add custom hooks for automation
+4. Begin using the agent
+
+---
+
+*Claude Cognitive Infrastructure v1.1.0*
+*Installation Verified: <date>*

--- a/Setup/Claude-Cognitive-Infrastructure/README.md
+++ b/Setup/Claude-Cognitive-Infrastructure/README.md
@@ -1,0 +1,84 @@
+# Claude Cognitive Infrastructure Setup
+
+Deploys the complete Claude Cognitive Infrastructure to any agent directory, enabling persistent memory, modular skills, context management, and event-driven hooks.
+
+## What This Playbook Does
+
+This playbook creates the foundational `.claude/` directory structure that gives Claude-based agents their cognitive capabilities:
+
+- **Memory System** - Persistent knowledge across sessions (learnings, preferences, work status)
+- **Skills Framework** - Modular domain expertise that activates based on intent
+- **Context Management** - Structured knowledge organized by domain
+- **Hooks System** - Event-driven automation for observability
+- **Configuration** - Settings and config files for customization
+
+## Infrastructure Structure
+
+After running this playbook, the agent will have:
+
+```
+Agent Directory/
+├── CLAUDE.md                    # Agent identity (single source of truth)
+└── .claude/
+    ├── settings.json            # Hook configuration
+    ├── VERSION                  # Infrastructure version tracking
+    ├── config/
+    │   └── config.yaml          # Runtime settings
+    ├── skills/
+    │   └── CORE/
+    │       └── SKILL.md         # Core skill with agent identity
+    ├── context/
+    │   ├── CLAUDE.md            # Context system documentation
+    │   ├── memory/              # Persistent memory
+    │   │   ├── learnings.md     # Facts about users/org
+    │   │   ├── user_preferences.md  # Working style
+    │   │   └── work_status.md   # Current tasks
+    │   ├── architecture/        # System design patterns
+    │   ├── design/              # Design principles
+    │   ├── development/         # Development context
+    │   ├── projects/            # Project-specific configs
+    │   ├── testing/             # Testing guidelines
+    │   ├── tools/               # Tool documentation
+    │   └── working/             # Working context
+    ├── hooks/                   # TypeScript event hooks
+    ├── agents/                  # Orchestration worker definitions
+    ├── scripts/                 # Utility scripts
+    └── examples/                # Reference examples
+```
+
+## Prerequisites
+
+- An agent directory where you want to install the infrastructure
+- The agent should have a clear purpose/role (used to generate identity)
+
+## Usage
+
+Run this playbook in the target agent's directory. The playbook will:
+
+1. Analyze the agent's purpose from directory name and any existing files
+2. Generate appropriate agent identity (name, mission, role)
+3. Create the complete `.claude/` directory structure
+4. Initialize memory files
+5. Create the CORE skill with agent identity
+6. Verify the installation
+
+## After Installation
+
+Once the infrastructure is installed, you can:
+
+1. Run **Knowledge Pack** playbooks to add domain expertise
+2. Customize the CLAUDE.md with additional instructions
+3. Add custom hooks for automation
+4. Start using the agent with full cognitive capabilities
+
+## Version
+
+Current infrastructure version: **1.1.0**
+
+## Credits
+
+The Claude Cognitive Infrastructure was influenced by [Daniel Miessler's](https://danielmiessler.com/) [Personal AI Infrastructure](https://github.com/danielmiessler/Personal_AI_Infrastructure) project, which pioneered many of the concepts around persistent memory, modular skills, and structured context for AI assistants.
+
+---
+
+*Claude Cognitive Infrastructure Setup Playbook*

--- a/Setup/Knowledge-Packs/Codebase-Expert/0_INITIALIZE.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/0_INITIALIZE.md
@@ -1,0 +1,95 @@
+# Phase 0: Initialize Codebase Expert Knowledge Pack
+
+## Objective
+
+Validate prerequisites for installing the Codebase Expert knowledge pack.
+
+## Prerequisites Check
+
+### 1. Verify Claude Cognitive Infrastructure Exists
+
+Check that the target agent has Claude Cognitive Infrastructure installed:
+
+```
+Required structure:
+.claude/
+├── config/
+├── context/
+├── skills/
+└── hooks/
+```
+
+**If `.claude/` directory does not exist:**
+- STOP - Run the "Claude Cognitive Infrastructure Setup" playbook first
+- This knowledge pack requires the base infrastructure
+
+### 2. Verify Runtime Available
+
+Check for Node.js or Bun:
+
+```bash
+node --version || bun --version
+```
+
+At least one must be available for embedding generation.
+
+### 3. Identify Target Codebase
+
+Determine which codebase to ingest:
+
+- Look for codebase path in the current directory or parent directories
+- Check for common indicators:
+  - `package.json` (Node.js project)
+  - `pyproject.toml` or `setup.py` (Python project)
+  - `go.mod` (Go project)
+  - `Cargo.toml` (Rust project)
+  - `src/` directory
+- If multiple codebases possible, use the primary project directory
+
+**Record the codebase path for the ANALYZE phase.**
+
+### 4. Check for Existing Installation
+
+Check if Codebase-Expert pack is already installed:
+
+```bash
+cat .claude/config/knowledge-packs.yaml 2>/dev/null | grep "codebase-expert"
+```
+
+If already installed:
+- This will be an **update** operation
+- Existing embeddings will be replaced
+- Other knowledge packs will be preserved
+
+### 5. Verify _Core Utilities
+
+Check that _Core utilities are available:
+
+If running from Maestro-Playbooks:
+- `Setup/Knowledge-Packs/_Core/` should contain the shared utilities
+
+If _Core not found:
+- The RAG hook will need to be copied from the playbook templates
+- Embedding will use local algorithm (no external API required)
+
+## Validation Checklist
+
+- [ ] `.claude/` directory exists with required subdirectories
+- [ ] Node.js or Bun runtime available
+- [ ] Target codebase identified and accessible
+- [ ] _Core utilities located or local fallback available
+
+## Output
+
+Record the following for subsequent phases:
+
+```yaml
+agent_directory: "<path to agent>"
+codebase_path: "<path to codebase to ingest>"
+is_update: <true/false>
+runtime: "<node/bun>"
+```
+
+## Next Phase
+
+Proceed to **1_ANALYZE.md** to scan the codebase and plan the ingestion.

--- a/Setup/Knowledge-Packs/Codebase-Expert/1_ANALYZE.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/1_ANALYZE.md
@@ -1,0 +1,143 @@
+# Phase 1: Analyze Codebase
+
+## Objective
+
+Scan the target codebase to understand its structure and plan the knowledge ingestion.
+
+## Analysis Steps
+
+### 1. Scan Directory Structure
+
+Map the codebase structure:
+
+```bash
+# Get directory tree (excluding common non-essential directories)
+find <codebase_path> -type d \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*" \
+  -not -path "*/dist/*" \
+  -not -path "*/build/*" \
+  -not -path "*/__pycache__/*" \
+  -not -path "*/venv/*" \
+  | head -50
+```
+
+### 2. Identify File Types
+
+Count files by extension to understand the codebase composition:
+
+```bash
+find <codebase_path> -type f \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*" \
+  | sed 's/.*\.//' | sort | uniq -c | sort -rn | head -20
+```
+
+### 3. Locate Key Files
+
+Identify high-value files for ingestion:
+
+**Documentation:**
+- `README.md` files at any level
+- `docs/` directory contents
+- `*.md` files in root
+- `CONTRIBUTING.md`, `CHANGELOG.md`
+
+**Configuration:**
+- `package.json` - project metadata
+- `tsconfig.json` - TypeScript config
+- `pyproject.toml` - Python project
+- `.env.example` - environment variables
+
+**Code Entry Points:**
+- `src/index.ts` or `src/main.ts`
+- `app.py` or `main.py`
+- `cmd/` directory (Go)
+- `src/lib.rs` (Rust)
+
+### 4. Estimate Ingestion Scope
+
+Calculate approximate ingestion size:
+
+```bash
+# Count total files to ingest
+find <codebase_path> -type f \
+  \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \
+     -o -name "*.py" -o -name "*.go" -o -name "*.rs" \
+     -o -name "*.md" -o -name "*.txt" \) \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*" \
+  -not -path "*/dist/*" \
+  | wc -l
+
+# Estimate total size
+find <codebase_path> -type f \
+  \( -name "*.ts" -o -name "*.tsx" -o -name "*.js" -o -name "*.jsx" \
+     -o -name "*.py" -o -name "*.go" -o -name "*.rs" \
+     -o -name "*.md" -o -name "*.txt" \) \
+  -not -path "*/node_modules/*" \
+  -not -path "*/.git/*" \
+  -not -path "*/dist/*" \
+  -exec cat {} \; 2>/dev/null | wc -c
+```
+
+### 5. Detect Project Type
+
+Determine the primary technology stack:
+
+| Indicator | Project Type |
+|-----------|--------------|
+| `package.json` with TypeScript | TypeScript/Node.js |
+| `package.json` without TypeScript | JavaScript/Node.js |
+| `pyproject.toml` or `setup.py` | Python |
+| `go.mod` | Go |
+| `Cargo.toml` | Rust |
+| `pom.xml` or `build.gradle` | Java |
+
+### 6. Identify Architecture Patterns
+
+Look for architectural indicators:
+
+- **Monorepo:** `packages/`, `apps/`, `libs/` directories
+- **Microservices:** Multiple service directories
+- **MVC:** `models/`, `views/`, `controllers/`
+- **Domain-Driven:** `domain/`, `infrastructure/`, `application/`
+
+## Analysis Output
+
+Document the following:
+
+```yaml
+codebase_analysis:
+  path: "<codebase_path>"
+  name: "<project name from package.json or directory>"
+  type: "<typescript|javascript|python|go|rust|mixed>"
+
+  structure:
+    total_files: <count>
+    total_size_kb: <size>
+    primary_language: "<language>"
+    secondary_languages: [<list>]
+
+  key_directories:
+    - src/
+    - docs/
+    - tests/
+
+  key_files:
+    - README.md
+    - package.json
+    - src/index.ts
+
+  exclusions:
+    - node_modules/
+    - dist/
+    - .git/
+
+  chunking_strategy: "code"  # or "mixed" for docs + code
+  estimated_chunks: <approximate count>
+```
+
+## Next Phase
+
+Proceed to **2_PLAN_STRUCTURE.md** to design the skill and plan chunk generation.

--- a/Setup/Knowledge-Packs/Codebase-Expert/2_PLAN_STRUCTURE.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/2_PLAN_STRUCTURE.md
@@ -1,0 +1,153 @@
+# Phase 2: Plan Structure
+
+## Objective
+
+Design the Codebase Expert skill and plan the chunking/embedding strategy.
+
+## Skill Design
+
+### Generate SKILL.md Content
+
+Based on the codebase analysis, create a skill definition:
+
+```markdown
+---
+name: Codebase-Expert
+version: 1.0.0
+priority: 75
+triggers:
+  - code
+  - codebase
+  - implementation
+  - architecture
+  - function
+  - class
+  - module
+  - how does
+  - where is
+  - explain the
+context_budget: 8000
+---
+
+# Codebase Expert: {{PROJECT_NAME}}
+
+## Overview
+
+Deep expertise in the {{PROJECT_NAME}} codebase. This skill provides:
+
+- **Code Understanding**: Explain how specific functions, classes, and modules work
+- **Architecture Knowledge**: Understand the overall system design and patterns
+- **Implementation Guidance**: Help implement features consistent with existing patterns
+- **Navigation**: Quickly locate relevant code for any task
+
+## Codebase Profile
+
+- **Type**: {{PROJECT_TYPE}}
+- **Primary Language**: {{PRIMARY_LANGUAGE}}
+- **Key Directories**: {{KEY_DIRECTORIES}}
+- **Architecture Pattern**: {{ARCHITECTURE_PATTERN}}
+
+## How to Use
+
+When answering questions about this codebase:
+
+1. **Check RAG Context**: Look for `.claude/context/working/rag-context.md` for auto-retrieved relevant code
+2. **Follow Patterns**: Recommend implementations consistent with existing code style
+3. **Reference Sources**: Cite specific files and line numbers when explaining code
+
+## Key Components
+
+{{KEY_COMPONENTS_LIST}}
+
+## Architectural Decisions
+
+{{ARCHITECTURE_NOTES}}
+```
+
+### Chunking Strategy
+
+Based on file types, determine chunking approach:
+
+| Content Type | Strategy | Chunk Size | Overlap |
+|--------------|----------|------------|---------|
+| TypeScript/JavaScript | `code` | 1500 chars | 100 |
+| Python | `code` | 1500 chars | 100 |
+| Go/Rust | `code` | 1500 chars | 100 |
+| Markdown docs | `markdown` | 1200 chars | 100 |
+| Config files | `fixed` | 800 chars | 50 |
+
+### File Priority
+
+Assign ingestion priority:
+
+**High Priority (ingest first):**
+- README files
+- Entry points (index.ts, main.py)
+- Core business logic
+- API definitions
+- Type definitions
+
+**Medium Priority:**
+- Utility functions
+- Helper modules
+- Tests (for understanding expected behavior)
+
+**Low Priority (optional):**
+- Generated files
+- Vendor code
+- Build scripts
+
+### Embedding Configuration
+
+```yaml
+embedding_config:
+  provider: "local"  # Use local embedding by default
+  dimensions: 384
+  batch_size: 50
+
+  # Optional: Use OpenAI for better quality
+  # provider: "openai"
+  # model: "text-embedding-3-small"
+  # api_key: "${OPENAI_API_KEY}"
+```
+
+## Plan Output
+
+Document the implementation plan:
+
+```yaml
+implementation_plan:
+  skill:
+    name: "Codebase-Expert"
+    path: ".claude/skills/Codebase-Expert/SKILL.md"
+    triggers: [code, codebase, implementation, architecture]
+
+  ingestion:
+    strategy: "code"
+    files_to_process: <count>
+    estimated_chunks: <count>
+    priority_order:
+      - high: [README.md, src/index.ts, ...]
+      - medium: [src/utils/*, tests/*]
+      - low: [scripts/*, configs/*]
+
+  storage:
+    vectors_path: ".claude/knowledge/vectors.json"
+    registry_path: ".claude/config/knowledge-packs.yaml"
+
+  hooks:
+    rag_hook: ".claude/hooks/rag-retrieval.ts"
+    hook_exists: <true/false>
+```
+
+## Generated Content Preview
+
+Preview the SKILL.md that will be created:
+
+```markdown
+# [Generated SKILL.md content here]
+```
+
+## Next Phase
+
+Proceed to **3_EVALUATE.md** to review the plan before implementation.

--- a/Setup/Knowledge-Packs/Codebase-Expert/3_EVALUATE.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/3_EVALUATE.md
@@ -1,0 +1,124 @@
+# Phase 3: Evaluate Plan
+
+## Objective
+
+Review and validate the implementation plan before proceeding.
+
+## Evaluation Checklist
+
+### 1. Skill Definition Review
+
+Verify the planned SKILL.md:
+
+- [ ] **Name** is clear and descriptive
+- [ ] **Triggers** cover relevant query patterns
+- [ ] **Priority** (75) allows other skills to take precedence when more specific
+- [ ] **Context budget** (8000) is appropriate for code explanations
+- [ ] **Overview** accurately describes the codebase
+
+### 2. Chunking Strategy Validation
+
+Verify chunking approach:
+
+- [ ] Strategy matches content types (code vs docs)
+- [ ] Chunk size appropriate for embedding model
+- [ ] Overlap prevents context loss at boundaries
+- [ ] Exclusions are correct (node_modules, .git, etc.)
+
+### 3. File Selection Review
+
+Verify file selection:
+
+- [ ] High-priority files include core business logic
+- [ ] Entry points are captured
+- [ ] Documentation is included
+- [ ] Tests included (for behavior reference)
+- [ ] No sensitive files (secrets, credentials) included
+
+**Security Check:**
+```
+Ensure these are EXCLUDED:
+- .env files
+- *credentials*
+- *secret*
+- *.pem, *.key
+- config files with API keys
+```
+
+### 4. Storage Validation
+
+Verify storage paths:
+
+- [ ] Vectors path is within `.claude/knowledge/`
+- [ ] Registry path is `.claude/config/knowledge-packs.yaml`
+- [ ] Skill path is `.claude/skills/Codebase-Expert/`
+
+### 5. Hook Configuration
+
+Verify RAG hook setup:
+
+- [ ] RAG hook will be installed at `.claude/hooks/rag-retrieval.ts`
+- [ ] Hook is registered in `.claude/settings.json`
+- [ ] Hook triggers on appropriate tools (Read, Grep, Glob)
+
+### 6. Conflict Check
+
+Check for potential conflicts:
+
+- [ ] No existing Codebase-Expert skill (or update is intended)
+- [ ] No conflicting embeddings in vector store
+- [ ] Settings.json can accommodate new hook
+
+## Estimated Impact
+
+Calculate the expected outcome:
+
+```yaml
+estimated_impact:
+  new_chunks: <count>
+  storage_size_kb: <estimated>
+  skill_file: 1
+  hook_files: 1 (if not exists)
+
+  capabilities_added:
+    - Answer questions about codebase structure
+    - Explain function/class implementations
+    - Guide feature implementation
+    - Navigate to relevant code quickly
+```
+
+## Risk Assessment
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| Large codebase slow to embed | Medium | Use batch processing, show progress |
+| Sensitive data exposure | Low | Exclusion patterns, security check |
+| Poor retrieval quality | Medium | Tune chunk size, test queries |
+| Hook conflicts | Low | Check existing hooks first |
+
+## Approval Gate
+
+**Confirm the following before proceeding:**
+
+1. ✓ Skill definition is appropriate for the codebase
+2. ✓ Chunking strategy will produce quality embeddings
+3. ✓ No sensitive files will be ingested
+4. ✓ Storage paths are correct
+5. ✓ No critical conflicts detected
+
+## Adjustments Needed
+
+If any issues found, document required changes:
+
+```yaml
+adjustments:
+  - description: "<what needs to change>"
+    reason: "<why>"
+    action: "<how to fix>"
+```
+
+## Next Phase
+
+If evaluation passes, proceed to **4_IMPLEMENT.md** to execute the plan.
+
+If adjustments needed, return to **2_PLAN_STRUCTURE.md** to revise.

--- a/Setup/Knowledge-Packs/Codebase-Expert/4_IMPLEMENT.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/4_IMPLEMENT.md
@@ -1,0 +1,235 @@
+# Phase 4: Implement Codebase Expert
+
+## Objective
+
+Execute the implementation plan: ingest codebase, generate embeddings, create skill, configure hooks.
+
+## Implementation Steps
+
+### 1. Create Directory Structure
+
+```bash
+# Create required directories
+mkdir -p .claude/skills/Codebase-Expert
+mkdir -p .claude/knowledge
+mkdir -p .claude/context/working
+```
+
+### 2. Install RAG Hook (if not exists)
+
+Check if RAG hook exists:
+
+```bash
+ls .claude/hooks/rag-retrieval.ts 2>/dev/null
+```
+
+If not exists, copy from _Core templates or create inline.
+
+Update `.claude/settings.json` to register the hook:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Grep|Glob|WebSearch|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "npx ts-node .claude/hooks/rag-retrieval.ts"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### 3. Scan and Chunk Codebase
+
+Process files in priority order:
+
+```typescript
+// Pseudo-code for ingestion
+const files = scanCodebase(codebasePath, {
+  include: ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.py', '**/*.md'],
+  exclude: ['**/node_modules/**', '**/.git/**', '**/dist/**']
+});
+
+const chunks = [];
+for (const file of files) {
+  const content = readFile(file);
+  const strategy = detectStrategy(file); // 'code' or 'markdown'
+  const fileChunks = chunkDocument(content, file, { strategy });
+  chunks.push(...fileChunks);
+}
+```
+
+### 4. Generate Embeddings
+
+Process chunks in batches:
+
+```typescript
+const BATCH_SIZE = 50;
+const documents = [];
+
+for (let i = 0; i < chunks.length; i += BATCH_SIZE) {
+  const batch = chunks.slice(i, i + BATCH_SIZE);
+  const embeddings = await embedBatch(batch.map(c => c.text), config);
+
+  for (let j = 0; j < batch.length; j++) {
+    documents.push({
+      id: batch[j].id,
+      text: batch[j].text,
+      embedding: embeddings[j].embedding,
+      metadata: {
+        ...batch[j].metadata,
+        pack_id: 'codebase-expert'
+      }
+    });
+  }
+
+  // Progress indicator
+  console.log(`Processed ${Math.min(i + BATCH_SIZE, chunks.length)}/${chunks.length} chunks`);
+}
+```
+
+### 5. Store Embeddings
+
+Save to vector store:
+
+```typescript
+const vectorStore = createVectorStore({
+  type: 'local',
+  path: '.claude/knowledge/vectors.json'
+});
+
+// Remove old codebase-expert embeddings (for updates)
+vectorStore.deleteByPack('codebase-expert');
+
+// Add new embeddings
+vectorStore.add(documents);
+```
+
+### 6. Register Knowledge Pack
+
+Update `.claude/config/knowledge-packs.yaml`:
+
+```yaml
+version: "1.0.0"
+installed_packs:
+  - id: codebase-expert
+    name: "Codebase Expert: {{PROJECT_NAME}}"
+    installed: "{{CURRENT_DATE}}"
+    version: "1.0.0"
+    sources:
+      - path: "{{CODEBASE_PATH}}"
+        type: "codebase"
+    embeddings_path: ".claude/knowledge/vectors.json"
+    skill_path: ".claude/skills/Codebase-Expert/SKILL.md"
+    metadata:
+      chunks: {{CHUNK_COUNT}}
+      files: {{FILE_COUNT}}
+      languages: [{{LANGUAGES}}]
+```
+
+### 7. Create Skill File
+
+Write `.claude/skills/Codebase-Expert/SKILL.md`:
+
+```markdown
+---
+name: Codebase-Expert
+version: 1.0.0
+priority: 75
+triggers:
+  - code
+  - codebase
+  - implementation
+  - architecture
+  - function
+  - class
+  - module
+  - how does
+  - where is
+  - explain the
+context_budget: 8000
+---
+
+# Codebase Expert: {{PROJECT_NAME}}
+
+## Overview
+
+Deep expertise in the {{PROJECT_NAME}} codebase ({{PRIMARY_LANGUAGE}}).
+
+This skill provides RAG-powered code understanding:
+- Automatic retrieval of relevant code snippets
+- Architecture and pattern knowledge
+- Implementation guidance consistent with existing code
+
+## Usage
+
+When this skill activates, relevant code context is automatically injected into `.claude/context/working/rag-context.md`.
+
+Check this file for pre-retrieved code snippets related to the current query.
+
+## Codebase Summary
+
+- **Location**: {{CODEBASE_PATH}}
+- **Type**: {{PROJECT_TYPE}}
+- **Files indexed**: {{FILE_COUNT}}
+- **Code chunks**: {{CHUNK_COUNT}}
+
+## Key Areas
+
+{{KEY_AREAS_LIST}}
+
+## Architecture Notes
+
+{{ARCHITECTURE_NOTES}}
+```
+
+### 8. Verify Installation
+
+Run verification checks:
+
+```bash
+# Check skill exists
+ls -la .claude/skills/Codebase-Expert/SKILL.md
+
+# Check embeddings exist
+ls -la .claude/knowledge/vectors.json
+
+# Check registry updated
+cat .claude/config/knowledge-packs.yaml
+
+# Check hook registered
+cat .claude/settings.json | grep rag-retrieval
+```
+
+## Implementation Summary
+
+Document what was created:
+
+```yaml
+implementation_summary:
+  skill_created: ".claude/skills/Codebase-Expert/SKILL.md"
+  embeddings_stored: ".claude/knowledge/vectors.json"
+  registry_updated: ".claude/config/knowledge-packs.yaml"
+  hook_installed: <true/false>
+
+  statistics:
+    files_processed: <count>
+    chunks_generated: <count>
+    embeddings_created: <count>
+    storage_size_kb: <size>
+
+  codebase:
+    name: "{{PROJECT_NAME}}"
+    path: "{{CODEBASE_PATH}}"
+    primary_language: "{{PRIMARY_LANGUAGE}}"
+```
+
+## Next Phase
+
+Proceed to **5_VERIFY.md** to test the installation.

--- a/Setup/Knowledge-Packs/Codebase-Expert/5_VERIFY.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/5_VERIFY.md
@@ -1,0 +1,179 @@
+# Phase 5: Verify Codebase Expert Installation
+
+## Objective
+
+Validate that the Codebase Expert knowledge pack is correctly installed and functioning.
+
+## Verification Tests
+
+### 1. Structure Verification
+
+Verify all files were created:
+
+```bash
+# Check skill file
+test -f .claude/skills/Codebase-Expert/SKILL.md && echo "✓ Skill file exists" || echo "✗ Skill file missing"
+
+# Check embeddings
+test -f .claude/knowledge/vectors.json && echo "✓ Vector store exists" || echo "✗ Vector store missing"
+
+# Check registry
+test -f .claude/config/knowledge-packs.yaml && echo "✓ Registry exists" || echo "✗ Registry missing"
+
+# Check RAG hook
+test -f .claude/hooks/rag-retrieval.ts && echo "✓ RAG hook exists" || echo "✗ RAG hook missing"
+```
+
+### 2. Content Verification
+
+Verify file contents are valid:
+
+```bash
+# Check SKILL.md has required frontmatter
+head -20 .claude/skills/Codebase-Expert/SKILL.md
+
+# Check vector store has documents
+cat .claude/knowledge/vectors.json | head -c 500
+
+# Check registry has codebase-expert entry
+grep "codebase-expert" .claude/config/knowledge-packs.yaml
+```
+
+### 3. Embedding Count Verification
+
+Verify expected number of embeddings:
+
+```bash
+# Count documents in vector store
+cat .claude/knowledge/vectors.json | grep -c '"id":'
+```
+
+**Expected**: Should match the chunk count from implementation phase.
+
+### 4. Hook Registration Verification
+
+Verify RAG hook is registered in settings:
+
+```bash
+# Check settings.json includes RAG hook
+cat .claude/settings.json | grep -A5 "PreToolUse"
+```
+
+### 5. Retrieval Test
+
+Test that retrieval works:
+
+```bash
+# Create a test query file
+echo '{"tool_name": "Grep", "tool_input": {"pattern": "main function"}}' > /tmp/test-query.json
+
+# Run RAG hook manually
+cd <agent_directory>
+cat /tmp/test-query.json | npx ts-node .claude/hooks/rag-retrieval.ts
+
+# Check if context was injected
+cat .claude/context/working/rag-context.md 2>/dev/null
+```
+
+### 6. Skill Trigger Test
+
+Verify skill triggers correctly:
+
+Test queries that should activate the skill:
+- "How does the authentication work in this codebase?"
+- "Where is the main entry point?"
+- "Explain the database connection code"
+
+These should:
+1. Trigger the RAG hook
+2. Inject relevant context to `rag-context.md`
+3. Activate the Codebase-Expert skill
+
+## Verification Checklist
+
+### Files Created
+- [ ] `.claude/skills/Codebase-Expert/SKILL.md` exists and valid
+- [ ] `.claude/knowledge/vectors.json` exists with embeddings
+- [ ] `.claude/config/knowledge-packs.yaml` has pack registered
+- [ ] `.claude/hooks/rag-retrieval.ts` exists (if newly installed)
+
+### Content Valid
+- [ ] SKILL.md has correct frontmatter (name, triggers, priority)
+- [ ] Vector store contains expected chunk count
+- [ ] Registry entry has correct metadata
+
+### Functionality
+- [ ] RAG hook executes without errors
+- [ ] Retrieval returns relevant results for test queries
+- [ ] Context injection creates/updates rag-context.md
+
+## Test Results
+
+Document verification results:
+
+```yaml
+verification_results:
+  structure:
+    skill_file: <pass/fail>
+    vector_store: <pass/fail>
+    registry: <pass/fail>
+    rag_hook: <pass/fail>
+
+  content:
+    skill_valid: <pass/fail>
+    embeddings_count: <count>
+    registry_entry: <pass/fail>
+
+  functionality:
+    hook_execution: <pass/fail>
+    retrieval_test: <pass/fail>
+    context_injection: <pass/fail>
+
+  overall_status: <PASS/FAIL>
+```
+
+## Troubleshooting
+
+### RAG Hook Not Triggering
+- Check `.claude/settings.json` has hook registered
+- Verify hook path is correct
+- Check for TypeScript compilation errors
+
+### No Relevant Results
+- Verify embeddings were generated correctly
+- Check chunk size isn't too large/small
+- Verify query is matching content
+
+### Context Not Injected
+- Check `.claude/context/working/` directory exists
+- Verify hook has write permissions
+- Check for errors in hook execution
+
+## Success Criteria
+
+The Codebase Expert knowledge pack is successfully installed when:
+
+1. ✓ All files exist in correct locations
+2. ✓ Embeddings count matches expected chunks
+3. ✓ Registry correctly lists the pack
+4. ✓ RAG hook executes without errors
+5. ✓ Test queries return relevant code snippets
+6. ✓ Context is injected into working memory
+
+## Installation Complete
+
+If all verifications pass:
+
+```
+✅ Codebase Expert Knowledge Pack Successfully Installed
+
+The agent now has deep expertise in the {{PROJECT_NAME}} codebase.
+
+Features enabled:
+- Automatic retrieval of relevant code on queries
+- Code explanation and navigation
+- Implementation guidance following existing patterns
+
+To update knowledge: Re-run this playbook
+To remove: Delete .claude/skills/Codebase-Expert/ and remove registry entry
+```

--- a/Setup/Knowledge-Packs/Codebase-Expert/README.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/README.md
@@ -1,0 +1,94 @@
+# Codebase Expert Knowledge Pack
+
+A knowledge pack that gives any Claude Cognitive Infrastructure agent deep expertise in a specific codebase.
+
+## Overview
+
+This playbook ingests a codebase, generates embeddings for code and documentation, and creates a "Codebase Expert" skill that enables RAG-powered code understanding.
+
+## Prerequisites
+
+- Target agent must have **Claude Cognitive Infrastructure** already installed
+- Target codebase must be accessible on the filesystem
+- Node.js/Bun runtime available
+
+## What Gets Created
+
+```
+.claude/
+├── config/
+│   └── knowledge-packs.yaml    # Pack registration (created/updated)
+├── knowledge/
+│   └── vectors.json            # Embeddings storage (created/updated)
+├── skills/
+│   └── Codebase-Expert/
+│       └── SKILL.md            # Codebase expertise skill
+└── context/
+    └── working/
+        └── rag-context.md      # Auto-injected relevant context
+```
+
+## Configuration
+
+The playbook automatically:
+
+1. **Scans** the target codebase for code files and documentation
+2. **Chunks** content using code-aware splitting (respects function/class boundaries)
+3. **Embeds** chunks using local embedding (or OpenAI if configured)
+4. **Registers** the pack in the knowledge registry
+5. **Creates** a Codebase-Expert skill
+
+### Supported File Types
+
+**Code:**
+- TypeScript/JavaScript (`.ts`, `.tsx`, `.js`, `.jsx`)
+- Python (`.py`)
+- Go (`.go`)
+- Rust (`.rs`)
+- And more...
+
+**Documentation:**
+- Markdown (`.md`, `.mdx`)
+- Text (`.txt`)
+- README files
+
+### Exclusions (automatic)
+
+- `node_modules/`
+- `.git/`
+- `dist/`, `build/`, `out/`
+- Binary files
+- Large generated files
+
+## Usage
+
+Run this playbook on an agent that already has Claude Cognitive Infrastructure:
+
+```
+Agent Directory/         # Must have .claude/ already
+├── CLAUDE.md
+└── .claude/
+    └── ...              # Existing infrastructure
+```
+
+Point the playbook at the codebase you want to ingest during the ANALYZE phase.
+
+## How RAG Works
+
+Once installed, the RAG retrieval hook:
+
+1. **Intercepts** query-related tool calls (Read, Grep, Glob, etc.)
+2. **Searches** the vector store for relevant code snippets
+3. **Injects** context into `.claude/context/working/rag-context.md`
+4. **Agent** automatically has relevant code context for responses
+
+## Updating Knowledge
+
+Re-run this playbook to update the codebase knowledge. It will:
+- Re-scan for new/changed files
+- Update embeddings
+- Preserve other installed knowledge packs
+
+---
+
+*Part of the Knowledge Packs system for Claude Cognitive Infrastructure*

--- a/Setup/Knowledge-Packs/Codebase-Expert/templates/skills/Codebase-Expert/SKILL.md
+++ b/Setup/Knowledge-Packs/Codebase-Expert/templates/skills/Codebase-Expert/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: Codebase-Expert
+version: 1.0.0
+priority: 75
+triggers:
+  - code
+  - codebase
+  - implementation
+  - architecture
+  - function
+  - class
+  - module
+  - how does
+  - where is
+  - explain the
+  - show me
+  - find the
+context_budget: 8000
+---
+
+# Codebase Expert: {{PROJECT_NAME}}
+
+## Overview
+
+Deep expertise in the **{{PROJECT_NAME}}** codebase. This skill provides RAG-powered code understanding with automatic retrieval of relevant code snippets.
+
+### Capabilities
+
+- **Code Understanding**: Explain how specific functions, classes, and modules work
+- **Architecture Knowledge**: Understand the overall system design and patterns
+- **Implementation Guidance**: Help implement features consistent with existing patterns
+- **Navigation**: Quickly locate relevant code for any task
+
+## How RAG Works
+
+When you ask questions about this codebase:
+
+1. The RAG hook automatically searches indexed code
+2. Relevant snippets are injected into `.claude/context/working/rag-context.md`
+3. This context informs responses about the codebase
+
+**Always check** `.claude/context/working/rag-context.md` for pre-retrieved context.
+
+## Codebase Profile
+
+| Attribute | Value |
+|-----------|-------|
+| **Project** | {{PROJECT_NAME}} |
+| **Type** | {{PROJECT_TYPE}} |
+| **Primary Language** | {{PRIMARY_LANGUAGE}} |
+| **Location** | {{CODEBASE_PATH}} |
+| **Files Indexed** | {{FILE_COUNT}} |
+| **Code Chunks** | {{CHUNK_COUNT}} |
+
+## Key Directories
+
+{{KEY_DIRECTORIES_LIST}}
+
+## Architecture Notes
+
+{{ARCHITECTURE_NOTES}}
+
+## Usage Guidelines
+
+When answering questions about this codebase:
+
+1. **Reference Sources**: Always cite specific files and line numbers
+2. **Follow Patterns**: Recommend implementations consistent with existing code style
+3. **Check Context**: Review `rag-context.md` for relevant retrieved snippets
+4. **Stay Current**: Note that indexed content reflects the codebase at ingestion time
+
+## Example Queries
+
+- "How does authentication work in this codebase?"
+- "Where is the database connection configured?"
+- "Explain the error handling pattern used"
+- "Show me how API routes are structured"
+- "What's the testing approach in this project?"
+
+---
+
+*Knowledge Pack: Codebase Expert | Updated: {{INSTALL_DATE}}*

--- a/Setup/Knowledge-Packs/_Core/README.md
+++ b/Setup/Knowledge-Packs/_Core/README.md
@@ -1,0 +1,66 @@
+# Knowledge Packs - Core Utilities
+
+Shared utilities for all Knowledge Packs in the Claude Cognitive Infrastructure ecosystem.
+
+## Overview
+
+Knowledge Packs are modular domain expertise packages that can be stacked on any agent with Claude Cognitive Infrastructure installed. This `_Core` directory contains shared utilities used by all packs.
+
+## Components
+
+### Registry System
+
+The registry tracks installed knowledge packs in `.claude/config/knowledge-packs.yaml`:
+
+```yaml
+installed_packs:
+  - id: codebase-expert
+    name: "Codebase Expert"
+    installed: 2025-01-03
+    version: "1.0.0"
+    sources:
+      - path: "/path/to/repo"
+        type: "codebase"
+    embeddings_path: ".claude/knowledge/codebase-expert/"
+```
+
+### Hooks
+
+- **`rag-retrieval.ts`** - PreToolUse hook that queries all installed knowledge packs and injects relevant context based on user intent
+
+### Libraries
+
+- **`registry.ts`** - Functions to read/write the knowledge packs registry
+- **`embeddings.ts`** - Embedding generation utilities (supports multiple providers)
+- **`vector-store.ts`** - Vector database abstraction (local JSON, Chroma, Pinecone)
+- **`chunking.ts`** - Document chunking strategies for different content types
+
+## Installation
+
+The `_Core` utilities are automatically installed when you run any Knowledge Pack playbook for the first time. They check for existing installation and skip if already present.
+
+## Supported Vector Stores
+
+1. **Local JSON** (default) - No external dependencies, stores in `.claude/knowledge/`
+2. **Chroma** - Local vector database
+3. **Pinecone** - Cloud vector database
+
+## How Knowledge Packs Work
+
+1. **Installation** - Pack playbook ingests source documents, generates embeddings
+2. **Registration** - Pack registers itself in `knowledge-packs.yaml`
+3. **Retrieval** - RAG hook queries relevant packs based on user intent
+4. **Injection** - Relevant context injected into agent's working memory
+
+## Creating New Knowledge Packs
+
+See existing packs (Codebase-Expert, Brian-Tracy-Teachings) as templates. Each pack needs:
+
+1. Standard 6-document playbook structure (0_INITIALIZE through 5_VERIFY)
+2. Skill template in `templates/skills/{PackName}/SKILL.md`
+3. Chunking strategy appropriate for content type
+4. Verification tests
+
+---
+
+*Part of the Claude Cognitive Infrastructure ecosystem*

--- a/Setup/Knowledge-Packs/_Core/hooks/rag-retrieval.ts
+++ b/Setup/Knowledge-Packs/_Core/hooks/rag-retrieval.ts
@@ -1,0 +1,237 @@
+#!/usr/bin/env npx ts-node
+/**
+ * RAG Retrieval Hook
+ *
+ * PreToolUse hook that queries installed knowledge packs and injects
+ * relevant context into the agent's working memory.
+ *
+ * Triggers on: Read, Grep, Glob, WebSearch (query-related tools)
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+
+// Types
+interface KnowledgePack {
+  id: string;
+  name: string;
+  embeddings_path: string;
+}
+
+interface VectorDocument {
+  id: string;
+  text: string;
+  embedding: number[];
+  metadata: {
+    source: string;
+    pack_id: string;
+    [key: string]: unknown;
+  };
+}
+
+interface HookInput {
+  tool_name: string;
+  tool_input: Record<string, unknown>;
+}
+
+// Cosine similarity
+function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) return 0;
+
+  let dot = 0, magA = 0, magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+
+  const mag = Math.sqrt(magA) * Math.sqrt(magB);
+  return mag === 0 ? 0 : dot / mag;
+}
+
+// Simple local embedding (matches embeddings.ts)
+function localEmbed(text: string, dimensions: number = 384): number[] {
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter(t => t.length > 0);
+
+  const embedding = new Array(dimensions).fill(0);
+
+  for (const token of tokens) {
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
+    }
+
+    for (let i = 0; i < 3; i++) {
+      const pos = (hash + i * 127) % dimensions;
+      embedding[pos] += 1 / (1 + i);
+    }
+  }
+
+  const magnitude = Math.sqrt(embedding.reduce((sum, val) => sum + val * val, 0));
+  if (magnitude > 0) {
+    for (let i = 0; i < dimensions; i++) {
+      embedding[i] /= magnitude;
+    }
+  }
+
+  return embedding;
+}
+
+// Extract query from tool input
+function extractQuery(toolName: string, toolInput: Record<string, unknown>): string | null {
+  switch (toolName) {
+    case "Read":
+      return toolInput.file_path as string || null;
+    case "Grep":
+      return toolInput.pattern as string || null;
+    case "Glob":
+      return toolInput.pattern as string || null;
+    case "WebSearch":
+      return toolInput.query as string || null;
+    case "Task":
+      return toolInput.prompt as string || null;
+    default:
+      return null;
+  }
+}
+
+// Load knowledge packs registry
+function loadRegistry(agentDir: string): KnowledgePack[] {
+  const registryPath = path.join(agentDir, ".claude", "config", "knowledge-packs.yaml");
+
+  if (!fs.existsSync(registryPath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(registryPath, "utf-8");
+    const registry = yaml.load(content) as { installed_packs?: KnowledgePack[] };
+    return registry?.installed_packs || [];
+  } catch {
+    return [];
+  }
+}
+
+// Load vector store
+function loadVectorStore(agentDir: string): VectorDocument[] {
+  const storePath = path.join(agentDir, ".claude", "knowledge", "vectors.json");
+
+  if (!fs.existsSync(storePath)) {
+    return [];
+  }
+
+  try {
+    const content = fs.readFileSync(storePath, "utf-8");
+    return JSON.parse(content);
+  } catch {
+    return [];
+  }
+}
+
+// Search for relevant documents
+function searchDocuments(
+  query: string,
+  documents: VectorDocument[],
+  topK: number = 3,
+  minScore: number = 0.3
+): Array<{ doc: VectorDocument; score: number }> {
+  if (documents.length === 0) return [];
+
+  const queryEmbedding = localEmbed(query);
+
+  const results = documents
+    .map(doc => ({
+      doc,
+      score: cosineSimilarity(queryEmbedding, doc.embedding),
+    }))
+    .filter(r => r.score >= minScore)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topK);
+
+  return results;
+}
+
+// Write context to working memory
+function injectContext(agentDir: string, results: Array<{ doc: VectorDocument; score: number }>, packs: KnowledgePack[]): void {
+  if (results.length === 0) return;
+
+  const packMap = new Map(packs.map(p => [p.id, p.name]));
+  const workingDir = path.join(agentDir, ".claude", "context", "working");
+
+  if (!fs.existsSync(workingDir)) {
+    fs.mkdirSync(workingDir, { recursive: true });
+  }
+
+  const contextPath = path.join(workingDir, "rag-context.md");
+
+  let content = `# Retrieved Knowledge Context\n\n`;
+  content += `*Auto-injected by RAG retrieval hook*\n\n`;
+
+  for (const { doc, score } of results) {
+    const packName = packMap.get(doc.metadata.pack_id) || doc.metadata.pack_id;
+    content += `## From: ${packName}\n`;
+    content += `**Source:** ${doc.metadata.source}\n`;
+    content += `**Relevance:** ${(score * 100).toFixed(1)}%\n\n`;
+    content += `${doc.text}\n\n`;
+    content += `---\n\n`;
+  }
+
+  fs.writeFileSync(contextPath, content, "utf-8");
+}
+
+// Main hook logic
+async function main() {
+  try {
+    // Read hook input from stdin
+    const input = fs.readFileSync(0, "utf-8");
+    const hookInput: HookInput = JSON.parse(input);
+
+    // Get agent directory (parent of .claude)
+    const agentDir = process.cwd();
+
+    // Only process query-related tools
+    const queryTools = ["Read", "Grep", "Glob", "WebSearch", "Task"];
+    if (!queryTools.includes(hookInput.tool_name)) {
+      process.exit(0);
+    }
+
+    // Extract query from tool input
+    const query = extractQuery(hookInput.tool_name, hookInput.tool_input);
+    if (!query || query.length < 3) {
+      process.exit(0);
+    }
+
+    // Load registry and check for installed packs
+    const packs = loadRegistry(agentDir);
+    if (packs.length === 0) {
+      process.exit(0);
+    }
+
+    // Load vector store
+    const documents = loadVectorStore(agentDir);
+    if (documents.length === 0) {
+      process.exit(0);
+    }
+
+    // Search for relevant documents
+    const results = searchDocuments(query, documents, 3, 0.3);
+
+    // Inject context if found
+    if (results.length > 0) {
+      injectContext(agentDir, results, packs);
+    }
+
+    process.exit(0);
+  } catch (error) {
+    // Fail silently - never crash Claude Code
+    console.error(`RAG hook error: ${error}`);
+    process.exit(0);
+  }
+}
+
+main();

--- a/Setup/Knowledge-Packs/_Core/lib/chunking.ts
+++ b/Setup/Knowledge-Packs/_Core/lib/chunking.ts
@@ -1,0 +1,286 @@
+/**
+ * Document Chunking Strategies
+ *
+ * Split documents into chunks suitable for embedding and retrieval.
+ * Different strategies for different content types.
+ */
+
+export interface Chunk {
+  id: string;
+  text: string;
+  metadata: {
+    source: string;
+    chunk_index: number;
+    start_line?: number;
+    end_line?: number;
+    type?: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface ChunkingConfig {
+  strategy: "fixed" | "semantic" | "code" | "markdown";
+  chunkSize?: number; // Target chunk size in characters
+  chunkOverlap?: number; // Overlap between chunks
+  minChunkSize?: number; // Minimum chunk size
+}
+
+const DEFAULT_CONFIG: ChunkingConfig = {
+  strategy: "fixed",
+  chunkSize: 1000,
+  chunkOverlap: 100,
+  minChunkSize: 100,
+};
+
+/**
+ * Generate a unique chunk ID
+ */
+function generateChunkId(source: string, index: number): string {
+  const hash = source
+    .split("")
+    .reduce((acc, char) => ((acc << 5) - acc + char.charCodeAt(0)) >>> 0, 0)
+    .toString(16);
+  return `${hash}-${index}`;
+}
+
+/**
+ * Fixed-size chunking with overlap
+ */
+function fixedChunk(
+  text: string,
+  source: string,
+  config: ChunkingConfig
+): Chunk[] {
+  const { chunkSize = 1000, chunkOverlap = 100, minChunkSize = 100 } = config;
+  const chunks: Chunk[] = [];
+
+  let start = 0;
+  let index = 0;
+
+  while (start < text.length) {
+    let end = start + chunkSize;
+
+    // Try to break at a natural boundary (sentence, paragraph)
+    if (end < text.length) {
+      const breakPoints = ["\n\n", "\n", ". ", "! ", "? "];
+      for (const bp of breakPoints) {
+        const lastBreak = text.lastIndexOf(bp, end);
+        if (lastBreak > start + minChunkSize) {
+          end = lastBreak + bp.length;
+          break;
+        }
+      }
+    }
+
+    const chunkText = text.slice(start, end).trim();
+
+    if (chunkText.length >= minChunkSize) {
+      chunks.push({
+        id: generateChunkId(source, index),
+        text: chunkText,
+        metadata: {
+          source,
+          chunk_index: index,
+          type: "fixed",
+        },
+      });
+      index++;
+    }
+
+    start = end - chunkOverlap;
+    if (start >= text.length - minChunkSize) break;
+  }
+
+  return chunks;
+}
+
+/**
+ * Code-aware chunking
+ * Respects function/class boundaries
+ */
+function codeChunk(
+  text: string,
+  source: string,
+  config: ChunkingConfig
+): Chunk[] {
+  const { chunkSize = 1500, minChunkSize = 100 } = config;
+  const chunks: Chunk[] = [];
+  const lines = text.split("\n");
+
+  // Patterns that indicate logical boundaries
+  const boundaryPatterns = [
+    /^(export\s+)?(async\s+)?function\s+\w+/, // Function declarations
+    /^(export\s+)?(default\s+)?class\s+\w+/, // Class declarations
+    /^(export\s+)?const\s+\w+\s*=\s*(async\s+)?\(/, // Arrow functions
+    /^(export\s+)?interface\s+\w+/, // TypeScript interfaces
+    /^(export\s+)?type\s+\w+/, // TypeScript types
+    /^def\s+\w+/, // Python functions
+    /^class\s+\w+/, // Python classes
+    /^##\s+/, // Markdown headers
+  ];
+
+  let currentChunk: string[] = [];
+  let currentSize = 0;
+  let chunkStartLine = 0;
+  let index = 0;
+
+  function saveChunk(endLine: number) {
+    const chunkText = currentChunk.join("\n").trim();
+    if (chunkText.length >= minChunkSize) {
+      chunks.push({
+        id: generateChunkId(source, index),
+        text: chunkText,
+        metadata: {
+          source,
+          chunk_index: index,
+          start_line: chunkStartLine + 1,
+          end_line: endLine + 1,
+          type: "code",
+        },
+      });
+      index++;
+    }
+    currentChunk = [];
+    currentSize = 0;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const isBoundary = boundaryPatterns.some(p => p.test(line.trim()));
+
+    // Start new chunk at logical boundaries if current chunk is large enough
+    if (isBoundary && currentSize > minChunkSize) {
+      saveChunk(i - 1);
+      chunkStartLine = i;
+    }
+
+    currentChunk.push(line);
+    currentSize += line.length + 1;
+
+    // Force split if chunk gets too large
+    if (currentSize >= chunkSize) {
+      saveChunk(i);
+      chunkStartLine = i + 1;
+    }
+  }
+
+  // Save remaining content
+  if (currentChunk.length > 0) {
+    saveChunk(lines.length - 1);
+  }
+
+  return chunks;
+}
+
+/**
+ * Markdown-aware chunking
+ * Respects header hierarchy and sections
+ */
+function markdownChunk(
+  text: string,
+  source: string,
+  config: ChunkingConfig
+): Chunk[] {
+  const { chunkSize = 1200, minChunkSize = 100 } = config;
+  const chunks: Chunk[] = [];
+  const lines = text.split("\n");
+
+  let currentChunk: string[] = [];
+  let currentSize = 0;
+  let currentHeader = "";
+  let chunkStartLine = 0;
+  let index = 0;
+
+  function saveChunk(endLine: number) {
+    const chunkText = currentChunk.join("\n").trim();
+    if (chunkText.length >= minChunkSize) {
+      chunks.push({
+        id: generateChunkId(source, index),
+        text: chunkText,
+        metadata: {
+          source,
+          chunk_index: index,
+          start_line: chunkStartLine + 1,
+          end_line: endLine + 1,
+          type: "markdown",
+          header: currentHeader || undefined,
+        },
+      });
+      index++;
+    }
+    currentChunk = [];
+    currentSize = 0;
+  }
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const headerMatch = line.match(/^(#{1,3})\s+(.+)/);
+
+    // New section at headers
+    if (headerMatch && currentSize > minChunkSize) {
+      saveChunk(i - 1);
+      chunkStartLine = i;
+      currentHeader = headerMatch[2];
+    } else if (headerMatch) {
+      currentHeader = headerMatch[2];
+    }
+
+    currentChunk.push(line);
+    currentSize += line.length + 1;
+
+    // Force split at paragraph boundaries if too large
+    if (currentSize >= chunkSize && line.trim() === "") {
+      saveChunk(i);
+      chunkStartLine = i + 1;
+    }
+  }
+
+  // Save remaining content
+  if (currentChunk.length > 0) {
+    saveChunk(lines.length - 1);
+  }
+
+  return chunks;
+}
+
+/**
+ * Chunk a document using the specified strategy
+ */
+export function chunkDocument(
+  text: string,
+  source: string,
+  config: ChunkingConfig = DEFAULT_CONFIG
+): Chunk[] {
+  switch (config.strategy) {
+    case "code":
+      return codeChunk(text, source, config);
+    case "markdown":
+      return markdownChunk(text, source, config);
+    case "semantic":
+    case "fixed":
+    default:
+      return fixedChunk(text, source, config);
+  }
+}
+
+/**
+ * Auto-detect chunking strategy based on file extension
+ */
+export function autoDetectStrategy(filename: string): ChunkingConfig["strategy"] {
+  const ext = filename.toLowerCase().split(".").pop();
+
+  const codeExtensions = [
+    "ts", "tsx", "js", "jsx", "py", "rb", "go", "rs", "java",
+    "c", "cpp", "h", "hpp", "cs", "swift", "kt", "scala"
+  ];
+
+  const markdownExtensions = ["md", "mdx", "markdown"];
+
+  if (codeExtensions.includes(ext || "")) {
+    return "code";
+  } else if (markdownExtensions.includes(ext || "")) {
+    return "markdown";
+  }
+
+  return "fixed";
+}

--- a/Setup/Knowledge-Packs/_Core/lib/embeddings.ts
+++ b/Setup/Knowledge-Packs/_Core/lib/embeddings.ts
@@ -1,0 +1,177 @@
+/**
+ * Embeddings Utilities
+ *
+ * Generate embeddings for text content using various providers.
+ * Supports local and cloud-based embedding models.
+ */
+
+export interface EmbeddingConfig {
+  provider: "local" | "openai" | "anthropic" | "cohere";
+  model?: string;
+  apiKey?: string;
+  dimensions?: number;
+}
+
+export interface EmbeddingResult {
+  text: string;
+  embedding: number[];
+  metadata?: Record<string, unknown>;
+}
+
+const DEFAULT_CONFIG: EmbeddingConfig = {
+  provider: "local",
+  dimensions: 384, // Default for local models
+};
+
+/**
+ * Simple local embedding using term frequency
+ * This is a fallback when no external API is available
+ */
+function localEmbed(text: string, dimensions: number = 384): number[] {
+  // Normalize and tokenize
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .split(/\s+/)
+    .filter(t => t.length > 0);
+
+  // Create a simple hash-based embedding
+  const embedding = new Array(dimensions).fill(0);
+
+  for (const token of tokens) {
+    // Hash the token to get consistent positions
+    let hash = 0;
+    for (let i = 0; i < token.length; i++) {
+      hash = (hash * 31 + token.charCodeAt(i)) >>> 0;
+    }
+
+    // Distribute the token across multiple dimensions
+    for (let i = 0; i < 3; i++) {
+      const pos = (hash + i * 127) % dimensions;
+      embedding[pos] += 1 / (1 + i);
+    }
+  }
+
+  // Normalize to unit vector
+  const magnitude = Math.sqrt(embedding.reduce((sum, val) => sum + val * val, 0));
+  if (magnitude > 0) {
+    for (let i = 0; i < dimensions; i++) {
+      embedding[i] /= magnitude;
+    }
+  }
+
+  return embedding;
+}
+
+/**
+ * Generate embeddings using OpenAI API
+ */
+async function openaiEmbed(
+  texts: string[],
+  apiKey: string,
+  model: string = "text-embedding-3-small"
+): Promise<number[][]> {
+  const response = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      input: texts,
+      model: model,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`OpenAI API error: ${response.statusText}`);
+  }
+
+  const data = await response.json();
+  return data.data.map((item: { embedding: number[] }) => item.embedding);
+}
+
+/**
+ * Generate embedding for a single text
+ */
+export async function embed(
+  text: string,
+  config: EmbeddingConfig = DEFAULT_CONFIG
+): Promise<EmbeddingResult> {
+  let embedding: number[];
+
+  switch (config.provider) {
+    case "openai":
+      if (!config.apiKey) {
+        throw new Error("OpenAI API key required");
+      }
+      const results = await openaiEmbed([text], config.apiKey, config.model);
+      embedding = results[0];
+      break;
+
+    case "local":
+    default:
+      embedding = localEmbed(text, config.dimensions);
+      break;
+  }
+
+  return {
+    text,
+    embedding,
+  };
+}
+
+/**
+ * Generate embeddings for multiple texts (batch)
+ */
+export async function embedBatch(
+  texts: string[],
+  config: EmbeddingConfig = DEFAULT_CONFIG
+): Promise<EmbeddingResult[]> {
+  switch (config.provider) {
+    case "openai":
+      if (!config.apiKey) {
+        throw new Error("OpenAI API key required");
+      }
+      const embeddings = await openaiEmbed(texts, config.apiKey, config.model);
+      return texts.map((text, i) => ({
+        text,
+        embedding: embeddings[i],
+      }));
+
+    case "local":
+    default:
+      return texts.map(text => ({
+        text,
+        embedding: localEmbed(text, config.dimensions),
+      }));
+  }
+}
+
+/**
+ * Calculate cosine similarity between two embeddings
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error("Embeddings must have same dimensions");
+  }
+
+  let dotProduct = 0;
+  let magnitudeA = 0;
+  let magnitudeB = 0;
+
+  for (let i = 0; i < a.length; i++) {
+    dotProduct += a[i] * b[i];
+    magnitudeA += a[i] * a[i];
+    magnitudeB += b[i] * b[i];
+  }
+
+  magnitudeA = Math.sqrt(magnitudeA);
+  magnitudeB = Math.sqrt(magnitudeB);
+
+  if (magnitudeA === 0 || magnitudeB === 0) {
+    return 0;
+  }
+
+  return dotProduct / (magnitudeA * magnitudeB);
+}

--- a/Setup/Knowledge-Packs/_Core/lib/registry.ts
+++ b/Setup/Knowledge-Packs/_Core/lib/registry.ts
@@ -1,0 +1,140 @@
+/**
+ * Knowledge Packs Registry
+ *
+ * Manages the registry of installed knowledge packs for an agent.
+ * Registry stored at .claude/config/knowledge-packs.yaml
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import * as yaml from "js-yaml";
+
+export interface KnowledgeSource {
+  path: string;
+  type: "codebase" | "documents" | "web" | "api";
+  include?: string[];
+  exclude?: string[];
+}
+
+export interface KnowledgePack {
+  id: string;
+  name: string;
+  installed: string;
+  version: string;
+  sources: KnowledgeSource[];
+  embeddings_path: string;
+  skill_path?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface KnowledgePacksRegistry {
+  version: string;
+  installed_packs: KnowledgePack[];
+}
+
+const DEFAULT_REGISTRY: KnowledgePacksRegistry = {
+  version: "1.0.0",
+  installed_packs: [],
+};
+
+/**
+ * Get the registry file path for an agent
+ */
+export function getRegistryPath(agentDir: string): string {
+  return path.join(agentDir, ".claude", "config", "knowledge-packs.yaml");
+}
+
+/**
+ * Load the knowledge packs registry
+ */
+export function loadRegistry(agentDir: string): KnowledgePacksRegistry {
+  const registryPath = getRegistryPath(agentDir);
+
+  if (!fs.existsSync(registryPath)) {
+    return { ...DEFAULT_REGISTRY };
+  }
+
+  try {
+    const content = fs.readFileSync(registryPath, "utf-8");
+    const registry = yaml.load(content) as KnowledgePacksRegistry;
+    return registry || { ...DEFAULT_REGISTRY };
+  } catch (error) {
+    console.error(`Error loading registry: ${error}`);
+    return { ...DEFAULT_REGISTRY };
+  }
+}
+
+/**
+ * Save the knowledge packs registry
+ */
+export function saveRegistry(agentDir: string, registry: KnowledgePacksRegistry): void {
+  const registryPath = getRegistryPath(agentDir);
+  const configDir = path.dirname(registryPath);
+
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+
+  const content = yaml.dump(registry, {
+    indent: 2,
+    lineWidth: 120,
+    noRefs: true,
+  });
+
+  fs.writeFileSync(registryPath, content, "utf-8");
+}
+
+/**
+ * Register a new knowledge pack
+ */
+export function registerPack(agentDir: string, pack: KnowledgePack): void {
+  const registry = loadRegistry(agentDir);
+
+  // Remove existing pack with same ID if present
+  registry.installed_packs = registry.installed_packs.filter(p => p.id !== pack.id);
+
+  // Add new pack
+  registry.installed_packs.push(pack);
+
+  saveRegistry(agentDir, registry);
+}
+
+/**
+ * Unregister a knowledge pack
+ */
+export function unregisterPack(agentDir: string, packId: string): boolean {
+  const registry = loadRegistry(agentDir);
+  const initialLength = registry.installed_packs.length;
+
+  registry.installed_packs = registry.installed_packs.filter(p => p.id !== packId);
+
+  if (registry.installed_packs.length < initialLength) {
+    saveRegistry(agentDir, registry);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Get a specific knowledge pack by ID
+ */
+export function getPack(agentDir: string, packId: string): KnowledgePack | undefined {
+  const registry = loadRegistry(agentDir);
+  return registry.installed_packs.find(p => p.id === packId);
+}
+
+/**
+ * Check if a knowledge pack is installed
+ */
+export function isPackInstalled(agentDir: string, packId: string): boolean {
+  return getPack(agentDir, packId) !== undefined;
+}
+
+/**
+ * Get all installed packs
+ */
+export function getAllPacks(agentDir: string): KnowledgePack[] {
+  const registry = loadRegistry(agentDir);
+  return registry.installed_packs;
+}

--- a/Setup/Knowledge-Packs/_Core/lib/vector-store.ts
+++ b/Setup/Knowledge-Packs/_Core/lib/vector-store.ts
@@ -1,0 +1,198 @@
+/**
+ * Vector Store Abstraction
+ *
+ * Provides a unified interface for storing and querying embeddings.
+ * Supports local JSON storage (default) and external vector databases.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+import { cosineSimilarity } from "./embeddings";
+
+export interface VectorDocument {
+  id: string;
+  text: string;
+  embedding: number[];
+  metadata: {
+    source: string;
+    chunk_index?: number;
+    pack_id: string;
+    [key: string]: unknown;
+  };
+}
+
+export interface SearchResult {
+  document: VectorDocument;
+  score: number;
+}
+
+export interface VectorStoreConfig {
+  type: "local" | "chroma" | "pinecone";
+  path?: string; // For local storage
+  apiKey?: string; // For cloud providers
+  indexName?: string;
+}
+
+/**
+ * Local JSON-based vector store
+ * Simple but effective for small to medium knowledge bases
+ */
+export class LocalVectorStore {
+  private storePath: string;
+  private documents: VectorDocument[] = [];
+
+  constructor(storePath: string) {
+    this.storePath = storePath;
+    this.load();
+  }
+
+  /**
+   * Load documents from disk
+   */
+  private load(): void {
+    if (fs.existsSync(this.storePath)) {
+      try {
+        const content = fs.readFileSync(this.storePath, "utf-8");
+        this.documents = JSON.parse(content);
+      } catch (error) {
+        console.error(`Error loading vector store: ${error}`);
+        this.documents = [];
+      }
+    }
+  }
+
+  /**
+   * Save documents to disk
+   */
+  private save(): void {
+    const dir = path.dirname(this.storePath);
+    if (!fs.existsSync(dir)) {
+      fs.mkdirSync(dir, { recursive: true });
+    }
+    fs.writeFileSync(this.storePath, JSON.stringify(this.documents, null, 2), "utf-8");
+  }
+
+  /**
+   * Add documents to the store
+   */
+  add(documents: VectorDocument[]): void {
+    // Remove duplicates by ID
+    const existingIds = new Set(this.documents.map(d => d.id));
+    const newDocs = documents.filter(d => !existingIds.has(d.id));
+
+    this.documents.push(...newDocs);
+    this.save();
+  }
+
+  /**
+   * Update or insert documents
+   */
+  upsert(documents: VectorDocument[]): void {
+    for (const doc of documents) {
+      const index = this.documents.findIndex(d => d.id === doc.id);
+      if (index >= 0) {
+        this.documents[index] = doc;
+      } else {
+        this.documents.push(doc);
+      }
+    }
+    this.save();
+  }
+
+  /**
+   * Delete documents by ID
+   */
+  delete(ids: string[]): void {
+    const idSet = new Set(ids);
+    this.documents = this.documents.filter(d => !idSet.has(d.id));
+    this.save();
+  }
+
+  /**
+   * Delete all documents for a specific pack
+   */
+  deleteByPack(packId: string): void {
+    this.documents = this.documents.filter(d => d.metadata.pack_id !== packId);
+    this.save();
+  }
+
+  /**
+   * Search for similar documents
+   */
+  search(queryEmbedding: number[], options: {
+    topK?: number;
+    packIds?: string[];
+    minScore?: number;
+  } = {}): SearchResult[] {
+    const { topK = 5, packIds, minScore = 0.0 } = options;
+
+    let candidates = this.documents;
+
+    // Filter by pack IDs if specified
+    if (packIds && packIds.length > 0) {
+      const packIdSet = new Set(packIds);
+      candidates = candidates.filter(d => packIdSet.has(d.metadata.pack_id));
+    }
+
+    // Calculate similarities
+    const results: SearchResult[] = candidates.map(doc => ({
+      document: doc,
+      score: cosineSimilarity(queryEmbedding, doc.embedding),
+    }));
+
+    // Filter by minimum score and sort by similarity
+    return results
+      .filter(r => r.score >= minScore)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, topK);
+  }
+
+  /**
+   * Get all documents
+   */
+  getAll(): VectorDocument[] {
+    return [...this.documents];
+  }
+
+  /**
+   * Get documents by pack ID
+   */
+  getByPack(packId: string): VectorDocument[] {
+    return this.documents.filter(d => d.metadata.pack_id === packId);
+  }
+
+  /**
+   * Get document count
+   */
+  count(): number {
+    return this.documents.length;
+  }
+
+  /**
+   * Get document count by pack
+   */
+  countByPack(packId: string): number {
+    return this.documents.filter(d => d.metadata.pack_id === packId).length;
+  }
+}
+
+/**
+ * Create a vector store instance
+ */
+export function createVectorStore(config: VectorStoreConfig): LocalVectorStore {
+  switch (config.type) {
+    case "local":
+    default:
+      if (!config.path) {
+        throw new Error("Path required for local vector store");
+      }
+      return new LocalVectorStore(config.path);
+  }
+}
+
+/**
+ * Get the default vector store path for an agent
+ */
+export function getDefaultStorePath(agentDir: string): string {
+  return path.join(agentDir, ".claude", "knowledge", "vectors.json");
+}

--- a/manifest.json
+++ b/manifest.json
@@ -155,6 +155,52 @@
       "loopEnabled": true,
       "maxLoops": 30,
       "prompt": "# Market Research Agent Prompt\n\n**IMPORTANT: Configure the placeholders below before running this playbook.**\n\n---\n\n## Research Configuration\n\n### Target Market\n<!-- CONFIGURE: Replace the example below with your target market -->\n**MARKET_TOPIC:** `Electric Vehicle Charging Infrastructure`\n\n<!-- Examples of market topics:\n- \"AI-Powered Developer Tools\"\n- \"Plant-Based Meat Alternatives\"\n- \"Enterprise Kubernetes Platforms\"\n- \"Direct-to-Consumer Hearing Aids\"\n- \"Carbon Capture Technologies\"\n-->\n\n### Output Location\n<!-- CONFIGURE: Replace with your desired output folder path -->\n**OUTPUT_FOLDER:** `{{AUTORUN_FOLDER}}/vault`\n\n<!-- This is where all research markdown files will be created -->\n\n---\n\n## Agent Instructions\n\nYou are a market research agent building a comprehensive knowledge vault about the configured market topic. Your goal is to create an interconnected set of markdown documents that provide deep insight into the market landscape.\n\n### Your Capabilities\n- **Web Search**: Use web search extensively to gather current market information\n- **Structured Research**: Follow templates to ensure consistent, comparable entity profiles\n- **Knowledge Linking**: Create `[[wiki-style]]` links between related entities\n- **Incremental Building**: Each loop iteration adds one well-researched entity to the vault\n\n### Entity Types to Research\nDepending on the market, research these entity categories:\n- **Companies**: Key players, startups, incumbents in the space\n- **Products/Services**: Notable offerings in the market\n- **People**: Founders, executives, thought leaders, analysts\n- **Technologies**: Core technologies, platforms, standards\n- **Trends**: Market trends, growth drivers, disruptions\n- **Investors**: VCs, corporate investors active in the space\n- **Regulations**: Relevant laws, standards, compliance requirements\n- **Events**: Conferences, trade shows, industry gatherings\n\n### Output Standards\n- All files in markdown format\n- Use `[[Entity Name]]` syntax for inter-page links\n- Include sources with URLs for all factual claims\n- Create an INDEX.md as the central launch page\n- Organize files in subfolders by entity type\n\n### Research Quality\n- Prioritize recent information (last 2 years)\n- Cross-reference multiple sources\n- Note when information is uncertain or conflicting\n- Include both qualitative insights and quantitative data where available\n\n---\n\n## Specialized Agents\n\nAfter initialization (`0_INITIALIZE.md`), the vault will contain specialized agents in the `Agents/` folder (also accessible via `.claude/agents`):\n\n| Agent | Purpose |\n|-------|--------|\n| `company-researcher` | Research and create company profiles |\n| `product-researcher` | Research and create product/service profiles |\n| `person-researcher` | Research and create key people profiles |\n| `technology-researcher` | Research and create technology profiles |\n| `trend-researcher` | Research and analyze market trends |\n\n### Using Agents\n\nYou can spawn these agents using the Task tool to research specific entities:\n\n```\nTask: \"Research Acme Corp for the knowledge vault\"\nAgent: company-researcher\n```\n\nEach agent will:\n1. Use web search to gather information\n2. Create a structured markdown profile\n3. Add `[[wiki-links]]` to related entities\n4. Update INDEX.md with the new entry\n\n---\n\n## Slash Commands\n\nAfter initialization, the vault will contain commands in the `Commands/` folder (also accessible via `.claude/commands`):\n\n| Command | Purpose |\n|---------|--------|\n| `/research` | Research a specific entity and add to vault |\n\n---\n\n## Working Style\n\n- **Keep going until done** - Complete research tasks without unnecessary pauses\n- **Use agents for entity research** - Spawn specialized agents for each entity type\n- **Maintain connections** - Always add `[[wiki-links]]` between related entities\n- **Update INDEX.md** - Keep the launch page current with all researched entities\n"
+    },
+    {
+      "id": "setup-cognitive-infrastructure",
+      "title": "Claude Cognitive Infrastructure",
+      "description": "Deploys the complete Claude Cognitive Infrastructure to any agent directory, enabling persistent memory, modular skills, context management, and event-driven hooks.",
+      "category": "Setup",
+      "subcategory": "Claude-Cognitive-Infrastructure",
+      "author": "Stephan Chenette",
+      "authorLink": "https://github.com/stephanchenette",
+      "tags": ["infrastructure", "memory", "skills", "context", "hooks", "agent-setup"],
+      "lastUpdated": "2026-01-04",
+      "path": "Setup/Claude-Cognitive-Infrastructure",
+      "documents": [
+        { "filename": "0_INITIALIZE", "resetOnCompletion": false },
+        { "filename": "1_ANALYZE", "resetOnCompletion": false },
+        { "filename": "2_PLAN_STRUCTURE", "resetOnCompletion": false },
+        { "filename": "3_EVALUATE", "resetOnCompletion": false },
+        { "filename": "4_IMPLEMENT", "resetOnCompletion": false },
+        { "filename": "5_VERIFY", "resetOnCompletion": false }
+      ],
+      "loopEnabled": false,
+      "maxLoops": 1,
+      "prompt": null
+    },
+    {
+      "id": "setup-knowledge-pack-codebase-expert",
+      "title": "Codebase Expert Knowledge Pack",
+      "description": "Installs the Codebase Expert knowledge pack, enabling RAG-powered code understanding with semantic search across the codebase.",
+      "category": "Setup",
+      "subcategory": "Knowledge-Packs",
+      "author": "Stephan Chenette",
+      "authorLink": "https://github.com/stephanchenette",
+      "tags": ["knowledge-pack", "codebase", "rag", "semantic-search", "code-understanding"],
+      "lastUpdated": "2026-01-04",
+      "path": "Setup/Knowledge-Packs/Codebase-Expert",
+      "documents": [
+        { "filename": "0_INITIALIZE", "resetOnCompletion": false },
+        { "filename": "1_ANALYZE", "resetOnCompletion": false },
+        { "filename": "2_PLAN_STRUCTURE", "resetOnCompletion": false },
+        { "filename": "3_EVALUATE", "resetOnCompletion": false },
+        { "filename": "4_IMPLEMENT", "resetOnCompletion": false },
+        { "filename": "5_VERIFY", "resetOnCompletion": false }
+      ],
+      "loopEnabled": false,
+      "maxLoops": 1,
+      "prompt": null
     }
   ]
 }


### PR DESCRIPTION
## Summary

Introduces the **Setup** category with playbooks for deploying Claude Cognitive Infrastructure to any agent directory.

### Claude Cognitive Infrastructure

Deploys the foundational `.claude/` directory structure enabling:
- **Persistent memory system** (learnings, preferences, work status)
- **Modular skills framework** with CORE identity skill
- **Structured context management** by domain
- **Event-driven hooks** capability
- **Complete agent identity** configuration

Influenced by [Daniel Miessler's Personal AI Infrastructure](https://github.com/danielmiessler/Personal_AI_Infrastructure) project.

### Knowledge Packs

Modular expertise layers that extend the base infrastructure:
- **_Core**: Shared RAG utilities (embeddings, vector store, chunking, registry)
- **Codebase-Expert**: RAG-powered code understanding and semantic search

## Files Added

```
Setup/
├── Claude-Cognitive-Infrastructure/   # Base infrastructure playbook
│   ├── README.md
│   ├── 0_INITIALIZE.md
│   ├── 1_ANALYZE.md
│   ├── 2_PLAN_STRUCTURE.md
│   ├── 3_EVALUATE.md
│   ├── 4_IMPLEMENT.md
│   └── 5_VERIFY.md
└── Knowledge-Packs/
    ├── _Core/                         # Shared utilities
    │   ├── README.md
    │   ├── hooks/rag-retrieval.ts
    │   └── lib/*.ts
    └── Codebase-Expert/               # Code understanding pack
        ├── README.md
        ├── 0_INITIALIZE.md - 5_VERIFY.md
        └── templates/skills/Codebase-Expert/SKILL.md
```

## Usage

1. Run **Claude-Cognitive-Infrastructure** playbook first (creates base `.claude/` structure)
2. Run **Knowledge Pack** playbooks to add domain expertise

🤖 Generated with [Claude Code](https://claude.com/claude-code)