### PR TITLE
Disable MD031 markdown linting rule in configuration

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -2,6 +2,7 @@
 	"MD013": false,
 	"MD022": false,
 	"MD024": false,
+	"MD031": false,
 	"MD032": false,
 	"MD040": false,
 	"MD041": false,


### PR DESCRIPTION
# Disable MD031 markdown linting rule in configuration

One more markdownlint rule to make sure markdownlint does not munge the existing playbooks.