### PR TITLE
[codex] add PR bot thread cleanup playbook

### DIFF
--- a/Development/PR-Bot-Cleanup/1_ANALYZE.md
+++ b/Development/PR-Bot-Cleanup/1_ANALYZE.md
@@ -1,0 +1,22 @@
+# Document 1: Analyze PR Context
+
+## Context
+
+- **Playbook**: PR Bot Thread Cleanup
+- **Agent**: {{AGENT_NAME}}
+- **Project**: {{AGENT_PATH}}
+- **Loop**: {{LOOP_NUMBER}}
+- **Date**: {{DATE}}
+- **Working Folder**: {{AUTORUN_FOLDER}}
+
+## Tasks
+
+- [ ] Identify the target pull request from the current task context, Maestro GitHub metadata, or a supplied PR URL, then write `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_CONTEXT.md` with the repository, PR number, PR URL, base branch, head branch, current remote head SHA, and the source of truth used for each field.
+
+- [ ] Inspect the repository before changing code by checking project docs and validation hints in files such as `README*`, `CONTRIBUTING*`, `package.json`, `pnpm-workspace.yaml`, `turbo.json`, `Makefile`, `justfile`, `pyproject.toml`, `.github/workflows/*`, and any repo-specific developer guides, then append the likely fast validation commands, likely branch-level validation commands, package manager or task runner details, and any repo-specific constraints to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_CONTEXT.md`.
+
+- [ ] Check `git status --short`, the current branch, and whether the current worktree already matches the PR head branch and remote head SHA; if it does not or the tree is not safely reusable, create or switch to an isolated worktree using repo-native helpers when available and otherwise `git worktree`, then append the final worktree path, branch name, HEAD SHA, and whether a new worktree was created to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_CONTEXT.md`.
+
+- [ ] Fetch or sync the PR head branch locally, verify local `HEAD` matches the remote PR head SHA, and record any mismatch or recovery step in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_CONTEXT.md`; if matching the remote head is impossible, document the exact blocker and stop without editing code.
+
+- [ ] Create or update `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md` with a short section for loop `{{LOOP_NUMBER}}` that records the starting PR URL, starting head SHA, starting worktree path, and the validation commands you expect to use later in the loop.

--- a/Development/PR-Bot-Cleanup/2_FIND_THREADS.md
+++ b/Development/PR-Bot-Cleanup/2_FIND_THREADS.md
@@ -1,0 +1,20 @@
+# Document 2: Find Unresolved Bot Threads
+
+## Context
+
+- **Playbook**: PR Bot Thread Cleanup
+- **Agent**: {{AGENT_NAME}}
+- **Project**: {{AGENT_PATH}}
+- **Loop**: {{LOOP_NUMBER}}
+- **Date**: {{DATE}}
+- **Working Folder**: {{AUTORUN_FOLDER}}
+
+## Tasks
+
+- [ ] Re-read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_CONTEXT.md`, then query the current PR using Maestro GitHub tools first and `gh` only if needed, and create `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_THREADS.md` containing the current PR URL, head SHA, and one section for each unresolved bot-authored review thread with bot name, comment URL, file path, line reference when available, a concise issue summary, and the raw unresolved status.
+
+- [ ] Include unresolved threads from CodeRabbit and Greptile even if their login names vary slightly, but exclude human review threads entirely; if thread-level unresolved state is unavailable from Maestro tools, use `gh api graphql` or another minimal `gh` query and record that fallback in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_THREADS.md`.
+
+- [ ] Query the latest meaningful GitHub check state for the PR head SHA using Maestro GitHub tools first and `gh` fallback second, then append the check summary, any failing job names, and any obvious environment-only caveats to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_THREADS.md`.
+
+- [ ] If zero unresolved bot threads are found, append an explicit zero-count summary for each supported bot to `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_THREADS.md` so later documents can exit cleanly without guessing.

--- a/Development/PR-Bot-Cleanup/3_EVALUATE.md
+++ b/Development/PR-Bot-Cleanup/3_EVALUATE.md
@@ -1,0 +1,20 @@
+# Document 3: Evaluate Findings
+
+## Context
+
+- **Playbook**: PR Bot Thread Cleanup
+- **Agent**: {{AGENT_NAME}}
+- **Project**: {{AGENT_PATH}}
+- **Loop**: {{LOOP_NUMBER}}
+- **Date**: {{DATE}}
+- **Working Folder**: {{AUTORUN_FOLDER}}
+
+## Tasks
+
+- [ ] Re-read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_THREADS.md`, inspect the current PR head for each unresolved bot thread, and create `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with one section per thread that classifies it as `STALE`, `DUPLICATE`, `PENDING`, `BLOCKED`, or `MANUAL`, plus the concrete evidence used for that judgment.
+
+- [ ] Resolve any bot thread that is already fixed, stale, or duplicated on the current head immediately on GitHub, record the thread URL and reason in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`, and append the same action to `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`; do not touch human review threads.
+
+- [ ] For each thread that remains `PENDING`, search the repository for nearby existing implementations and patterns before proposing changes, then update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with the smallest safe batch grouping so the next implementation step addresses one coherent concern only.
+
+- [ ] For each thread that cannot be resolved safely, mark it `BLOCKED` or `MANUAL` in `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` with the exact missing context, failing command, missing secret, missing dependency, or policy decision that prevents automated closure.

--- a/Development/PR-Bot-Cleanup/4_IMPLEMENT.md
+++ b/Development/PR-Bot-Cleanup/4_IMPLEMENT.md
@@ -1,0 +1,22 @@
+# Document 4: Implement One Fix Batch
+
+## Context
+
+- **Playbook**: PR Bot Thread Cleanup
+- **Agent**: {{AGENT_NAME}}
+- **Project**: {{AGENT_PATH}}
+- **Loop**: {{LOOP_NUMBER}}
+- **Date**: {{DATE}}
+- **Working Folder**: {{AUTORUN_FOLDER}}
+
+## Tasks
+
+- [ ] Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`, choose the next smallest coherent group of `PENDING` findings, and implement only the minimal code changes required to address that batch while reusing existing project patterns and avoiding unrelated cleanup.
+
+- [ ] Run focused validation for the touched files or subsystem first, then run the most relevant branch-level validation command discovered earlier, and append the exact commands, exact outcomes, and any exact blocker text to both `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` and `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`.
+
+- [ ] If the batch changed the branch, commit and push only the current PR head branch using the repository's normal workflow, then re-poll unresolved CodeRabbit and Greptile threads plus the latest GitHub checks and append the new head SHA, resolved thread URLs, remaining unresolved counts, and latest check state to `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`.
+
+- [ ] After the push, resolve any bot thread that is now provably stale or fixed on the pushed head, record each resolution in `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`, and update `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md` so completed work is marked `IMPLEMENTED`.
+
+- [ ] If no `PENDING` findings existed at the start of this document, append a no-op note with the current head SHA and reason for skipping implementation to `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`.

--- a/Development/PR-Bot-Cleanup/5_PROGRESS.md
+++ b/Development/PR-Bot-Cleanup/5_PROGRESS.md
@@ -1,0 +1,30 @@
+# Document 5: Progress Gate
+
+## Context
+
+- **Playbook**: PR Bot Thread Cleanup
+- **Agent**: {{AGENT_NAME}}
+- **Project**: {{AGENT_PATH}}
+- **Loop**: {{LOOP_NUMBER}}
+- **Date**: {{DATE}}
+- **Working Folder**: {{AUTORUN_FOLDER}}
+
+## Tasks
+
+- [ ] Read `{{AUTORUN_FOLDER}}/LOOP_{{LOOP_NUMBER}}_PLAN.md`, count how many findings remain in each status bucket, and append a concise loop summary with the current head SHA, status counts, and latest check state to `{{AUTORUN_FOLDER}}/BOT_THREAD_LEDGER.md`.
+
+- [ ] If no `PENDING` findings remain and only `IMPLEMENTED`, `STALE`, `DUPLICATE`, `BLOCKED`, or `MANUAL` findings are left, do not reset documents 1-4 and instead write `{{AUTORUN_FOLDER}}/FINAL_SUMMARY.md` summarizing the PR URL, latest head SHA, threads resolved by bot, latest validation and check status, remaining blockers if any, and whether the PR is accept-ready.
+
+- [ ] Exit cleanly only after `{{AUTORUN_FOLDER}}/FINAL_SUMMARY.md` states one of two outcomes explicitly: `ACCEPT_READY` when no unresolved bot threads remain, or `BLOCKED` when only precisely documented blockers or manual-review items remain.
+
+## Reset Tasks (Only if real bot work remains)
+
+- [ ] If `PENDING` findings still exist and they are safe for automated work, uncheck all tasks in `{{AUTORUN_FOLDER}}/1_ANALYZE.md` so the next loop refreshes PR metadata, branch state, and validation commands.
+
+- [ ] If `PENDING` findings still exist and they are safe for automated work, uncheck all tasks in `{{AUTORUN_FOLDER}}/2_FIND_THREADS.md` so the next loop re-polls unresolved bot threads and current check state.
+
+- [ ] If `PENDING` findings still exist and they are safe for automated work, uncheck all tasks in `{{AUTORUN_FOLDER}}/3_EVALUATE.md` so the next loop rebuilds the adjudication plan against the latest pushed head.
+
+- [ ] If `PENDING` findings still exist and they are safe for automated work, uncheck all tasks in `{{AUTORUN_FOLDER}}/4_IMPLEMENT.md` so the next loop can execute the next smallest coherent batch.
+
+**Important**: Leave the reset tasks above unchecked when no safe `PENDING` findings remain. That is how the pipeline exits instead of looping forever.

--- a/Development/PR-Bot-Cleanup/README.md
+++ b/Development/PR-Bot-Cleanup/README.md
@@ -1,0 +1,107 @@
+# PR Bot Thread Cleanup Playbook
+
+A Maestro Auto Run playbook for cleaning up unresolved PR review threads from bot reviewers such as CodeRabbit and Greptile without widening scope or trampling the branch.
+
+## Requirements
+
+**Agent Prompt**: This playbook works with Maestro's default agent prompt.
+
+**GitHub Access**: Best results require Maestro's GitHub integration and a working `gh` CLI session. The playbook should prefer Maestro GitHub tools first and use `gh` only when thread-level metadata or check details are unavailable.
+
+## Overview
+
+This playbook creates an automated loop that:
+1. Reconstructs the live PR context and local branch state
+2. Finds unresolved bot-authored review threads and captures them in working artifacts
+3. Evaluates each thread against the current PR head to separate stale findings from real work
+4. Implements the smallest valid fix batch, validates it, pushes it, and resolves newly stale bot threads
+5. Repeats until no unresolved bot threads remain or a hard blocker is documented precisely
+
+## Document Chain
+
+| Document | Purpose | Reset on Completion? |
+|----------|---------|---------------------|
+| `1_ANALYZE.md` | Reconstruct PR metadata, branch state, validation commands, and loop context | No |
+| `2_FIND_THREADS.md` | Enumerate unresolved bot threads and latest GitHub check state | No |
+| `3_EVALUATE.md` | Adjudicate each bot thread as stale, duplicate, real, or blocked and create the next fix plan | No |
+| `4_IMPLEMENT.md` | Apply one small coherent fix batch, validate, push, and resolve now-stale bot threads | No |
+| `5_PROGRESS.md` | Continue looping only when real unresolved bot work remains | **Yes** |
+
+## Generated Files
+
+Each loop iteration creates working documents in the Auto Run folder:
+
+- `LOOP_{{LOOP_NUMBER}}_CONTEXT.md` - PR metadata, branch state, worktree path, validation plan
+- `LOOP_{{LOOP_NUMBER}}_THREADS.md` - Unresolved bot thread inventory with URLs and file/line references
+- `LOOP_{{LOOP_NUMBER}}_PLAN.md` - Thread dispositions and next implementation batch
+- `BOT_THREAD_LEDGER.md` - Cumulative record of pushes, resolved thread URLs, and blockers
+- `FINAL_SUMMARY.md` - Final handoff when the playbook exits cleanly
+
+## Supported Review Bots
+
+This playbook is intentionally bot-focused. It should:
+
+- Include unresolved threads from CodeRabbit and Greptile
+- Tolerate minor variations in bot login names
+- Ignore human review threads completely
+- Resolve stale bot threads only when the current PR head proves the issue is already fixed or no longer applicable
+
+## How It Works
+
+### Loop Control
+
+`5_PROGRESS.md` is the gate:
+
+- If `LOOP_{{LOOP_NUMBER}}_PLAN.md` still contains `PENDING` findings that are real and safe to fix automatically, it resets documents 1-4 and the next loop starts.
+- If the only remaining items are `STALE`, `DUPLICATE`, `IMPLEMENTED`, `BLOCKED`, or `MANUAL`, it does not reset documents 1-4 and the pipeline exits.
+
+### One Batch Per Loop
+
+Document 4 should handle only one coherent batch per loop. That keeps validation tight, commits small, and thread resolution obvious after each push.
+
+## Recommended Setup
+
+### Standard Cleanup Run
+
+```text
+Loop Mode: ON
+Max Loops: 10
+Documents:
+  1_ANALYZE.md       [Reset: OFF]
+  2_FIND_THREADS.md  [Reset: OFF]
+  3_EVALUATE.md      [Reset: OFF]
+  4_IMPLEMENT.md     [Reset: OFF]
+  5_PROGRESS.md      [Reset: ON]
+```
+
+### Review-First Dry Run
+
+```text
+Loop Mode: OFF
+Run once to inspect LOOP_1_THREADS.md and LOOP_1_PLAN.md before allowing automated fixes
+```
+
+## Template Variables Used
+
+- `{{AGENT_NAME}}` - Name of the Maestro agent
+- `{{AGENT_PATH}}` - Root path of the target repository
+- `{{AUTORUN_FOLDER}}` - Path to this Auto Run folder
+- `{{LOOP_NUMBER}}` - Current loop iteration
+- `{{DATE}}` - Current date
+- `{{CWD}}` - Current working directory
+
+## Safety Rules
+
+1. Never resolve human review threads.
+2. Never assume a bot finding is still real without checking the current PR head.
+3. Never broaden scope into unrelated cleanup.
+4. Never hand-wave a validation failure. Record the exact command and exact blocker.
+5. Keep scratch artifacts in the Auto Run folder or other untracked working locations unless the repo already tracks a scratch area by convention.
+
+## Tips
+
+1. Start with Maestro GitHub tools and fall back to `gh` only when needed.
+2. Match the local worktree SHA to the remote PR head before editing code.
+3. Resolve stale bot threads immediately after a push while evidence is fresh.
+4. Prefer focused validation before umbrella project commands.
+5. Exit cleanly when only documented blockers remain.

--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,28 @@
 {
-  "lastUpdated": "2025-12-26",
+  "lastUpdated": "2026-04-10",
   "playbooks": [
+    {
+      "id": "development-pr-bot-cleanup",
+      "title": "PR Bot Thread Cleanup",
+      "description": "Systematically cleans up unresolved CodeRabbit and Greptile PR review threads by separating stale bot comments from real findings, applying small validated fixes, and resolving newly stale threads after each push.",
+      "category": "Development",
+      "subcategory": "PR-Bot-Cleanup",
+      "author": "Jeff Scott Ward",
+      "authorLink": "https://github.com/jeffscottward",
+      "tags": ["pull-request", "github", "coderabbit", "greptile", "review-bots", "thread-cleanup"],
+      "lastUpdated": "2026-04-10",
+      "path": "Development/PR-Bot-Cleanup",
+      "documents": [
+        { "filename": "1_ANALYZE", "resetOnCompletion": false },
+        { "filename": "2_FIND_THREADS", "resetOnCompletion": false },
+        { "filename": "3_EVALUATE", "resetOnCompletion": false },
+        { "filename": "4_IMPLEMENT", "resetOnCompletion": false },
+        { "filename": "5_PROGRESS", "resetOnCompletion": true }
+      ],
+      "loopEnabled": true,
+      "maxLoops": 10,
+      "prompt": null
+    },
     {
       "id": "development-security",
       "title": "Security Audit",


### PR DESCRIPTION
## Summary
- add a new `Development/PR-Bot-Cleanup` exchange playbook for cleaning up unresolved CodeRabbit and Greptile PR review threads
- convert the original internal 4-phase notes into the exchange's standard 5-document loop format
- register the playbook in `manifest.json` and update the top-level `lastUpdated` date

## Why
The original playbook content existed as internal Auto Run docs, but it was not packaged in the repository structure required by the Maestro Playbook Exchange. This PR turns it into a reusable community playbook with a README, numbered documents, loop control, and manifest metadata.

## User Impact
Users can import a playbook that reconstructs PR state, triages bot-authored review threads, applies small validated fix batches, resolves newly stale threads after pushes, and exits cleanly when the PR is accept-ready or explicitly blocked.

## Validation
- `jq empty manifest.json`
- Python manifest/path validation to confirm all referenced playbook paths and document files exist

## Notes
- The playbook is written to prefer Maestro GitHub integration first and use `gh` as a fallback for thread-level GitHub data.
- The loop gate uses explicit reset checkboxes so it matches how existing exchange playbooks control Maestro Auto Run loops.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added PR Bot Thread Cleanup playbook—a structured workflow to systematically identify, evaluate, and resolve unresolved bot-authored review threads on pull requests with integrated safety checks and validation.

* **Documentation**
  * Added comprehensive playbook guide covering PR context analysis, thread discovery, findings evaluation, batch implementation, and progress tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->